### PR TITLE
include CMakeDependentOption

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,7 +13,7 @@ PROJECT("tlsuv"
 message("Project: ${PROJECT_NAME}@v${PROJECT_VERSION}")
 include(cmake/project-is-top-level.cmake)
 include(cmake/variables.cmake)
-
+include(CMakeDependentOption)
 include(GNUInstallDirs)
 
 set(TLSUV_TLSLIB "openssl" CACHE STRING "TLS implementation library (openssl|mbedtls)")


### PR DESCRIPTION
this makes it possible for one to use cmake without presets.

    cmake -DCMAKE_TOOLCHAIN_FILE="${VCPKG_ROOT}/vcpkg/scripts/buildsystems/vcpkg.cmake"

