### PR TITLE
properly handle openssl errors

### DIFF
--- a/src/http.c
+++ b/src/http.c
@@ -177,11 +177,13 @@ static void on_tls_handshake(tls_link_t *tls, int status) {
             uv_async_send(&clt->proc);
             break;
 
-        case TLS_HS_ERROR:
-            UM_LOG(ERR, "handshake failed status[%d]", status);
+        case TLS_HS_ERROR: {
+            const char *err = tls->engine->api->strerror(tls->engine->engine);
+            UM_LOG(ERR, "handshake failed status[%d]: %s", status, tls->engine->api->strerror(tls->engine->engine));
             close_connection(clt);
-            fail_active_request(clt, UV_ECONNABORTED, uv_strerror(UV_ECONNABORTED));
+            fail_active_request(clt, UV_ECONNABORTED, err);
             break;
+        }
 
         default:
             UM_LOG(ERR, "unexpected handshake status[%d]", status);

--- a/src/openssl/engine.c
+++ b/src/openssl/engine.c
@@ -518,6 +518,8 @@ static void tls_free_ctx(tls_context *ctx) {
 
 static int tls_reset(void *engine) {
     struct openssl_engine *e = engine;
+    ERR_clear_error();
+
     if (!SSL_clear(e->ssl)) {
         int err = SSL_get_error(e->ssl, 0);
         UM_LOG(ERR, "error resetting TSL enging: %d(%s)", err, tls_error(err));
@@ -631,43 +633,6 @@ static int tls_set_own_cert(void *ctx, const char *cert_buf, size_t cert_len) {
     return 0;
 }
 
-#if 0
-
-static int tls_set_own_cert_p11(void *ctx, const char *cert_buf, size_t cert_len,
-        const char *pkcs11_lib, const char *pin, const char *slot, const char *key_id) {
-
-    struct tls_context *c = ctx;
-    c->own_key = calloc(1, sizeof(mbedtls_pk_context));
-    int rc = mp11_load_key(c->own_key, pkcs11_lib, pin, slot, key_id);
-    if (rc != CKR_OK) {
-        fprintf(stderr, "failed to load private key - %s", p11_strerror(rc));
-        mbedtls_pk_free(c->own_key);
-        free(c->own_key);
-        c->own_key = NULL;
-        return TLS_ERR;
-    }
-
-    c->own_cert = calloc(1, sizeof(mbedtls_x509_crt));
-    rc = mbedtls_x509_crt_parse(c->own_cert, (const unsigned char *)cert_buf, cert_len);
-    if (rc < 0) {
-        rc = mbedtls_x509_crt_parse_file(c->own_cert, cert_buf);
-        if (rc < 0) {
-            fprintf(stderr, "failed to load certificate");
-            mbedtls_x509_crt_free(c->own_cert);
-            free(c->own_cert);
-            c->own_cert = NULL;
-
-            mbedtls_pk_free(c->own_key);
-            free(c->own_key);
-            c->own_key = NULL;
-            return TLS_ERR;
-        }
-    }
-
-    mbedtls_ssl_conf_own_cert(&c->config, c->own_cert, c->own_key);
-    return TLS_OK;
-}
-#endif
 
 static tls_handshake_state tls_hs_state(void *engine) {
     struct openssl_engine *eng = (struct openssl_engine *) engine;
@@ -686,24 +651,33 @@ tls_continue_hs(void *engine, char *in, size_t in_bytes, char *out, size_t *out_
     if (in_bytes > 0) {
         BIO_write(eng->in, (const unsigned char *)in, (int)in_bytes);
     }
+    ERR_clear_error();
 
-    int state = SSL_do_handshake(eng->ssl);
-    int err = SSL_get_error(eng->ssl, state);
+    int rc = SSL_do_handshake(eng->ssl);
+
     if (BIO_ctrl_pending(eng->out) > 0) {
         *out_bytes = BIO_read(eng->out, (unsigned char *) out, (int)maxout);
     } else {
         *out_bytes = 0;
     }
 
-    OSSL_HANDSHAKE_STATE hs_state = SSL_get_state(eng->ssl);
-    if (hs_state == TLS_ST_OK) {
+    if (rc == 1) { // handshake completed
         return TLS_HS_COMPLETE;
     }
-    else if (err == SSL_ERROR_WANT_READ || err == SSL_ERROR_WANT_WRITE) {
-        return TLS_HS_CONTINUE;
+
+    int err = SSL_get_error(eng->ssl, rc);
+
+    if (rc == 0) { // handshake encountered an error and was shutdown
+        eng->error = err;
+        UM_LOG(ERR, "openssl: handshake was terminated: %s", tls_error(eng->error));
+        return TLS_HS_ERROR;
     }
-    else {
-        eng->error = state;
+
+    if (err == SSL_ERROR_WANT_READ || err == SSL_ERROR_WANT_WRITE) {
+        return TLS_HS_CONTINUE;
+    } else { // something else is wrong
+        eng->error = err;
+        UM_LOG(ERR, "openssl: handshake error: %s", tls_error(eng->error));
         return TLS_HS_ERROR;
     }
 }
@@ -721,15 +695,19 @@ static const char* tls_get_alpn(void *engine) {
 
 static int tls_write(void *engine, const char *data, size_t data_len, char *out, size_t *out_bytes, size_t maxout) {
     struct openssl_engine *eng = (struct openssl_engine *) engine;
+    ERR_clear_error();
+
     size_t wrote = 0;
     while (data_len > wrote) {
-        int rc = SSL_write(eng->ssl, (const unsigned char *)(data + wrote), (int)(data_len - wrote));
-        if (rc < 0) {
-            eng->error = rc;
-            return rc;
+        size_t written;
+        if (!SSL_write_ex(eng->ssl, (const unsigned char *)(data + wrote), data_len - wrote, &written)) {
+            eng->error = SSL_get_error(eng->ssl, 0);
+            UM_LOG(ERR, "openssl: write error: %s", tls_error(eng->error));
+            return -1;
         }
-        wrote += rc;
+        wrote += written;
     }
+
     if (BIO_ctrl_pending(eng->out) > 0)
         *out_bytes = BIO_read(eng->out, (unsigned char *)out, (int)maxout);
     else
@@ -746,18 +724,21 @@ tls_read(void *engine, const char *ssl_in, size_t ssl_in_len, char *out, size_t 
         BIO_write(eng->in, (const unsigned char *)ssl_in, (int)ssl_in_len);
     }
 
-    int rc;
     int err = SSL_ERROR_NONE;
     uint8_t *writep = (uint8_t*)out;
     size_t total_out = 0;
 
-    while((maxout - total_out > 0) && (rc = SSL_read(eng->ssl, writep, (int)(maxout - total_out))) > 0) {
-        total_out += rc;
-        writep += rc;
-    }
+    ERR_clear_error();
+    while(maxout - total_out > 0) {
 
-    if (rc < 0) {
-        err = SSL_get_error(eng->ssl, rc);
+        size_t read_bytes;
+        if (!SSL_read_ex(eng->ssl, writep, maxout - total_out, &read_bytes)) {
+            err = SSL_get_error(eng->ssl, 0);
+            break;
+        }
+
+        total_out += read_bytes;
+        writep += read_bytes;
     }
 
     *out_bytes = total_out;
@@ -772,8 +753,8 @@ tls_read(void *engine, const char *ssl_in, size_t ssl_in_len, char *out, size_t 
     }
 
     if (err != SSL_ERROR_NONE) {
-        eng->error = rc;
-        UM_LOG(ERR, "mbedTLS: %0x(%s)", rc, tls_error(eng->error));
+        eng->error = err;
+        UM_LOG(ERR, "openssl read: %s", tls_error(eng->error));
         return TLS_ERR;
     }
 
@@ -786,7 +767,13 @@ tls_read(void *engine, const char *ssl_in, size_t ssl_in_len, char *out, size_t 
 
 static int tls_close(void *engine, char *out, size_t *out_bytes, size_t maxout) {
     struct openssl_engine *eng = (struct openssl_engine *) engine;
-    SSL_shutdown(eng->ssl);
+    ERR_clear_error();
+
+    int rc = SSL_shutdown(eng->ssl);
+    if (rc < 0) {
+        int err = SSL_get_error(eng->ssl, rc);
+        UM_LOG(WARN, "openssl shutdown: %s", tls_error(err));
+    }
     if (BIO_ctrl_pending(eng->out) > 0)
         *out_bytes = BIO_read(eng->out, (unsigned char *)out, (int)maxout);
     else

--- a/src/openssl/keys.h
+++ b/src/openssl/keys.h
@@ -28,7 +28,7 @@ struct priv_key_s {
     EVP_PKEY *pkey;
 };
 
-const char *tls_error(int code);
+const char *tls_error(unsigned long code);
 
 void pub_key_init(struct pub_key_s *pubkey);
 void priv_key_init(struct priv_key_s *privkey);

--- a/src/tlsuv.c
+++ b/src/tlsuv.c
@@ -112,9 +112,9 @@ int tlsuv_stream_nodelay(tlsuv_stream_t *clt, int nodelay) {
 }
 
 static void on_tls_hs(tls_link_t *tls_link, int status) {
-    tlsuv_stream_t *mbed = tls_link->data;
+    tlsuv_stream_t *stream = tls_link->data;
 
-    uv_connect_t *req = mbed->conn_req;
+    uv_connect_t *req = stream->conn_req;
     if (req == NULL) {
         return;
     }
@@ -122,12 +122,13 @@ static void on_tls_hs(tls_link_t *tls_link, int status) {
     if (status == TLS_HS_COMPLETE) {
         req->cb(req, 0);
     } else if (status == TLS_HS_ERROR) {
+        UM_LOG(WARN, "handshake failed: %s", tls_link->engine->api->strerror(tls_link->engine->engine));
         req->cb(req, UV_ECONNABORTED);
     } else {
         UM_LOG(WARN, "unexpected handshake status[%d]", status);
         req->cb(req, UV_EINVAL);
     }
-    mbed->conn_req = NULL;
+    stream->conn_req = NULL;
 }
 
 static void on_src_connect(tlsuv_src_t *src, int status, void *ctx) {


### PR DESCRIPTION
- make sure meaning full error is stored in engine.error field
- clear openssl error stack before any SSL_xxx operation