### PR TITLE
better support for ALPN

### DIFF
--- a/include/tlsuv/http.h
+++ b/include/tlsuv/http.h
@@ -134,7 +134,7 @@ struct tlsuv_http_s {
 
     bool ssl;
     tls_context *tls;
-    tls_engine *engine;
+    tlsuv_engine_t engine;
 
     um_header_list headers;
 

--- a/include/tlsuv/tls_link.h
+++ b/include/tlsuv/tls_link.h
@@ -22,11 +22,11 @@ typedef void (*tls_handshake_cb)(tls_link_t *l, int status);
 struct tls_link_s {
     UV_LINK_FIELDS
 
-    tls_engine *engine;
+    tlsuv_engine_t engine;
     tls_handshake_cb hs_cb;
 };
 
 
-int tlsuv_tls_link_init(tls_link_t *tls, tls_engine *engine, tls_handshake_cb cb);
+int tlsuv_tls_link_init(tls_link_t *tls, tlsuv_engine_t engine, tls_handshake_cb cb);
 
 #endif//TLSUV_TLS_LINK_H

--- a/include/tlsuv/tlsuv.h
+++ b/include/tlsuv/tlsuv.h
@@ -57,7 +57,7 @@ struct tlsuv_stream_s {
     tls_link_t tls_link;
 
     tls_context *tls;
-    tls_engine *tls_engine;
+    tlsuv_engine_t tls_engine;
 
     char *host;
     uv_connect_t *conn_req; //a place to stash a connection request

--- a/include/tlsuv/tlsuv.h
+++ b/include/tlsuv/tlsuv.h
@@ -34,6 +34,8 @@ typedef void(*tlsuv_log_func)(int level, const char *file, unsigned int line, co
 void tlsuv_set_debug(int level, tlsuv_log_func output_f);
 
 int tlsuv_stream_init(uv_loop_t *l, tlsuv_stream_t *clt, tls_context *tls);
+int tlsuv_stream_set_protocols(tlsuv_stream_t *clt, int num, const char *protocols[]);
+const char* tlsuv_stream_get_protocol(tlsuv_stream_t *clt);
 int tlsuv_stream_keepalive(tlsuv_stream_t *clt, int keepalive, unsigned int delay);
 int tlsuv_stream_nodelay(tlsuv_stream_t *clt, int nodelay);
 
@@ -58,6 +60,8 @@ struct tlsuv_stream_s {
 
     tls_context *tls;
     tlsuv_engine_t tls_engine;
+    int alpn_count;
+    const char **alpn_protocols;
 
     char *host;
     uv_connect_t *conn_req; //a place to stash a connection request

--- a/sample/engine_test.c
+++ b/sample/engine_test.c
@@ -70,7 +70,7 @@ int main(int argc, char **argv) {
     printf("ip: %s\n", ip);
 
     tls_context *tls = default_tls_context(NULL, 0);
-    tls_engine *engine = tls->api->new_engine(tls->ctx, HOST);
+    tlsuv_engine_t engine = tls->api->new_engine(tls->ctx, HOST);
 
     SOCKET sock = socket(AF_INET, SOCK_STREAM, 0);
 
@@ -104,7 +104,7 @@ int main(int argc, char **argv) {
 
     int i = 0;
     do {
-        tls_handshake_state state = engine->api->handshake(engine->engine, ssl_in, in_bytes, ssl_out, &out_bytes,
+        tls_handshake_state state = engine->handshake(engine, ssl_in, in_bytes, ssl_out, &out_bytes,
                                                            sizeof(ssl_out));
 
         if (state == TLS_HS_COMPLETE) {
@@ -134,7 +134,7 @@ int main(int argc, char **argv) {
                       "User-Agent: HTTPie/1.0.2\n"
                       "\n";
 
-    engine->api->write(engine->engine, req, strlen(req), ssl_out, &out_bytes, sizeof(ssl_out));
+    engine->write(engine, req, strlen(req), ssl_out, &out_bytes, sizeof(ssl_out));
     printf("writing req=%zd bytes\n", out_bytes);
 
     send(sock, ssl_out, out_bytes, 0);
@@ -152,11 +152,11 @@ int main(int argc, char **argv) {
             in_bytes = 0;
         }
 
-        read_res = engine->api->read(engine->engine, ssl_in, in_bytes, resp, &resp_read, sizeof(resp));
+        read_res = engine->read(engine, ssl_in, in_bytes, resp, &resp_read, sizeof(resp));
         printf("%*.*s", (int) resp_read, (int) resp_read, resp);
     } while (read_res == TLS_READ_AGAIN || read_res == TLS_MORE_AVAILABLE);
 
-    engine->api->close(engine->engine, ssl_out, &out_bytes, sizeof(ssl_out));
+    engine->close(engine, ssl_out, &out_bytes, sizeof(ssl_out));
     send(sock, ssl_out, out_bytes, 0);
 
     sockClose(sock);
@@ -165,6 +165,6 @@ int main(int argc, char **argv) {
     WSACleanup();
 #endif
 
-    tls->api->free_engine(engine);
+    engine->free(engine);
     tls->api->free_ctx(tls);
 }

--- a/sample/engine_test.c
+++ b/sample/engine_test.c
@@ -71,6 +71,8 @@ int main(int argc, char **argv) {
 
     tls_context *tls = default_tls_context(NULL, 0);
     tlsuv_engine_t engine = tls->api->new_engine(tls->ctx, HOST);
+    const char *alpn[] = { "http/1.1" };
+    engine->set_protocols(engine, alpn, 1);
 
     SOCKET sock = socket(AF_INET, SOCK_STREAM, 0);
 
@@ -108,7 +110,7 @@ int main(int argc, char **argv) {
                                                            sizeof(ssl_out));
 
         if (state == TLS_HS_COMPLETE) {
-            printf("handshake complete\n");
+            printf("handshake complete alpn[%s]\n", engine->get_alpn(engine));
             break;
         }
         else if (state == TLS_HS_ERROR) {

--- a/src/http.c
+++ b/src/http.c
@@ -178,8 +178,8 @@ static void on_tls_handshake(tls_link_t *tls, int status) {
             break;
 
         case TLS_HS_ERROR: {
-            const char *err = tls->engine->api->strerror(tls->engine->engine);
-            UM_LOG(ERR, "handshake failed status[%d]: %s", status, tls->engine->api->strerror(tls->engine->engine));
+            const char *err = tls->engine->strerror(tls->engine);
+            UM_LOG(ERR, "handshake failed status[%d]: %s", status, tls->engine->strerror(tls->engine));
             close_connection(clt);
             fail_active_request(clt, UV_ECONNABORTED, err);
             break;
@@ -202,7 +202,7 @@ static void make_links(tlsuv_http_t *clt, uv_link_t *conn_src) {
         }
 
         if (clt->host_change) {
-            clt->tls->api->free_engine(clt->engine);
+            clt->engine->free(clt->engine);
             clt->engine = NULL;
             clt->host_change = false;
         }
@@ -423,7 +423,7 @@ int tlsuv_http_close(tlsuv_http_t *clt, tlsuv_http_close_cb close_cb) {
     close_connection(clt);
 
     if (clt->engine != NULL) {
-        clt->tls->api->free_engine(clt->engine);
+        clt->engine->free(clt->engine);
         clt->engine = NULL;
     }
     clt->tls = NULL;

--- a/src/mbedtls/engine.c
+++ b/src/mbedtls/engine.c
@@ -261,7 +261,7 @@ static void init_ssl_context(mbedtls_ssl_config *ssl_config, const char *cabuf, 
             return;
         }
         while (pCertContext = CertEnumCertificatesInStore(hCertStore, pCertContext)) {
-            mbedtls_x509_crt_parse(ca, pCertContext->pbCertEncoded, pCertContext->cbCertEncoded);
+            mbedtls_x509_crt_parse(engine->ca, pCertContext->pbCertEncoded, pCertContext->cbCertEncoded);
         }
         CertFreeCertificateContext(pCertContext);
         CertCloseStore(hCertStore, 0);

--- a/src/tlsuv.c
+++ b/src/tlsuv.c
@@ -122,7 +122,7 @@ static void on_tls_hs(tls_link_t *tls_link, int status) {
     if (status == TLS_HS_COMPLETE) {
         req->cb(req, 0);
     } else if (status == TLS_HS_ERROR) {
-        UM_LOG(WARN, "handshake failed: %s", tls_link->engine->api->strerror(tls_link->engine->engine));
+        UM_LOG(WARN, "handshake failed: %s", tls_link->engine->strerror(tls_link->engine));
         req->cb(req, UV_ECONNABORTED);
     } else {
         UM_LOG(WARN, "unexpected handshake status[%d]", status);
@@ -136,7 +136,8 @@ static void on_src_connect(tlsuv_src_t *src, int status, void *ctx) {
 
     if (status == 0) {
         if (clt->tls_engine != NULL) {
-            clt->tls->api->free_engine(clt->tls_engine);
+            clt->tls_engine->free(clt->tls_engine);
+            clt->tls_engine = NULL;
         }
         void *data = clt->data;
         clt->tls_engine = clt->tls->api->new_engine(clt->tls->ctx, clt->host);
@@ -206,7 +207,7 @@ int tlsuv_stream_free(tlsuv_stream_t *clt) {
         clt->host = NULL;
     }
     if (clt->tls_engine) {
-        clt->tls->api->free_engine(clt->tls_engine);
+        clt->tls_engine->free(clt->tls_engine);
         clt->tls_engine = NULL;
     }
     if (clt->socket) {

--- a/src/websocket.c
+++ b/src/websocket.c
@@ -442,7 +442,7 @@ static void on_ws_close(tlsuv_websocket_t *ws) {
         ws->host = NULL;
     }
     if (ws->tls && ws->tls_link.engine) {
-        ws->tls->api->free_engine(ws->tls_link.engine);
+        ws->tls_link.engine->free(ws->tls_link.engine);
         ws->tls_link.engine = NULL;
     }
     if (ws->src) {


### PR DESCRIPTION
set ALPN on the engine instance:

- allows to have one TLS context create engines for different kinds of connections
- refactor engine objects to be runtime polymorphic (simplify engine API)