### PR TITLE
combine set_own_key/cert into a single method

### DIFF
--- a/include/tlsuv/tls_engine.h
+++ b/include/tlsuv/tls_engine.h
@@ -156,18 +156,19 @@ struct tls_context_s {
     void (*free_cert)(tls_cert *cert);
 
     /**
+     * \brief set client certfificate credentials.
+     *
      * (Optional): if you bring your own engine this is probably not needed.
      * This method is provided to set client/server side cert on the default TLS context.
-     */
-    int (*set_own_cert)(tls_context *ctx, tls_cert cer);
-
-    /**
-     * set client auth key.
      *
-     * It also sets client certificate if the key has associated cert (pkcs11 keys)
-     * @param key
+     * @param ctx TLS context
+     * @param key private key, use NULL to clear client auth
+     * @param cert x509 certificate corresponding to the key,
+     *        may be NULL if private key implementation provides certificate (pkcs11)
+     *
+     * @return 0 for success, -1 on error (mismatched key/cert, or cert is not provided)
      */
-    int (*set_own_key)(tls_context *ctx, tlsuv_private_key_t key);
+    int (*set_own_cert)(tls_context *ctx, tlsuv_private_key_t key, tls_cert cert);
 
     /**
      * Sets custom server cert validation function.

--- a/sample/um-curl.c
+++ b/sample/um-curl.c
@@ -102,9 +102,8 @@ int main(int argc, char **argv) {
 
         if (cert && key) {
             tls->load_key(&tlsKey, key, strlen(key));
-            tls->set_own_key(tls, tlsKey);
             tls->load_cert(&tlsCert, cert, strlen(cert));
-            tls->set_own_cert(tls, tlsCert);
+            tls->set_own_cert(tls, tlsKey, tlsCert);
         }
         tlsuv_http_set_ssl(&app.clt, tls);
     }

--- a/tests/http_tests.cpp
+++ b/tests/http_tests.cpp
@@ -331,7 +331,7 @@ TEST_CASE("pkcs11_client_cert_test","[http]") {
         tlsuv_private_key_t pk;
         int rc = tls->load_pkcs11_key(&pk, to_str(HSM_LIB), nullptr, "2222", nullptr, keyName.c_str());
         REQUIRE(rc == 0);
-        CHECK(tls->set_own_key(tls, pk) == 0);
+        CHECK(tls->set_own_cert(tls, pk, NULL) == 0);
 
         test.run();
 
@@ -439,8 +439,7 @@ TEST_CASE("client_cert_test","[http]") {
         REQUIRE(rc == 0);
         tls_cert c = nullptr;
         CHECK(tls->load_cert(&c, cert, strlen(cert)) == 0);
-        CHECK(tls->set_own_cert(tls, c) == 0);
-        CHECK(tls->set_own_key(tls, pk) == 0);
+        CHECK(tls->set_own_cert(tls, pk, c) == 0);
 
         test.run();
 


### PR DESCRIPTION
OpenSSL requires certain order when changing key/cert pair