### PR TITLE
fix and normalize CSR generation (`engine.generate_csr()`):

### DIFF
--- a/src/mbedtls/engine.c
+++ b/src/mbedtls/engine.c
@@ -957,13 +957,15 @@ static int generate_csr(tlsuv_private_key_t key, char **pem, size_t *pemlen, ...
     mbedtls_x509write_csr_set_key(&csr, pk);
     uint8_t pembuf[4096];
     if ((ret = mbedtls_x509write_csr_pem(&csr, pembuf, sizeof(pembuf), mbedtls_ctr_drbg_random, &ctr_drbg)) < 0) {
-        UM_LOG(ERR, "mbedtls_x509write_csr_pem returned %d", ret);
+        UM_LOG(ERR, "mbedtls_x509write_csr_pem returned %d/%s", ret, mbedtls_error(ret));
         goto on_error;
     }
     on_error:
     if (ret == 0) {
         *pem = strdup((const char*)pembuf);
-        *pemlen = strlen((const char*)pembuf) + 1;
+        if (pemlen) {
+            *pemlen = strlen((const char *)pembuf);
+        }
     }
     mbedtls_x509write_csr_free(&csr);
     return ret;

--- a/src/openssl/engine.c
+++ b/src/openssl/engine.c
@@ -1036,6 +1036,9 @@ goto on_error;            \
         size_t len = BIO_ctrl_pending(b);
         *pem = calloc(1, len + 1);
         BIO_read(b, *pem, (int)len);
+        if (pemlen) {
+            *pemlen = len;
+        }
     }
 
     BIO_free(b);

--- a/tests/key_tests.cpp
+++ b/tests/key_tests.cpp
@@ -148,14 +148,25 @@ TEST_CASE("gen csr", "[engine]") {
     REQUIRE(ctx->generate_key(&key) == 0);
 
     char *pem;
-    size_t pemlen;
-    REQUIRE(ctx->generate_csr_to_pem(key, &pem, &pemlen,
-                                          "C", "US",
-                                          "O", "OpenZiti",
-                                          "OU", "Developers",
-                                          "CN", "CSR test",
-                                          NULL) == 0);
+    size_t pemlen = 0;
+    CHECK(ctx->generate_csr_to_pem(key, &pem, &pemlen,
+                                   "C", "US",
+                                   "O", "OpenZiti",
+                                   "OU", "Developers",
+                                   "CN", "CSR test",
+                                   NULL) == 0);
+    CHECK(pemlen == strlen(pem));
     printf("CSR:\n%.*s\n", (int)pemlen, pem);
+    free(pem);
+    pem = nullptr;
+
+    CHECK(ctx->generate_csr_to_pem(key, &pem, nullptr,
+                                   "C", "US",
+                                   "O", "OpenZiti",
+                                   "OU", "Developers",
+                                   "CN", "CSR test",
+                                   NULL) == 0);
+    printf("CSR:\n%s\n", pem);
 
     key->free(key);
     ctx->free_ctx(ctx);


### PR DESCRIPTION
- openssl engine was not populating `pemlen` output
- mbedtls engine was crashing if `pemlen` was not specified