### PR TITLE
refactor TLS engine IO

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,7 +41,8 @@ set(tlsuv_sources
         src/compression.h
         src/p11.c
         src/p11.h
-        )
+        src/util.h
+)
 
 if(USE_OPENSSL)
     set(tlsImpl openssl)

--- a/include/tlsuv/tls_engine.h
+++ b/include/tlsuv/tls_engine.h
@@ -17,12 +17,10 @@
 
 #include <stdlib.h>
 #include <stdio.h>
+#include <uv.h>
 
 #if _WIN32
-#include <uv/win.h>
 #pragma comment (lib, "crypt32.lib")
-#else
-#include <uv/unix.h>
 #endif
 
 #ifdef __cplusplus

--- a/include/tlsuv/tls_link.h
+++ b/include/tlsuv/tls_link.h
@@ -31,5 +31,6 @@ struct tls_link_s {
 
 
 int tlsuv_tls_link_init(tls_link_t *tls, tlsuv_engine_t engine, tls_handshake_cb cb);
+void tlsuv_tls_link_free(tls_link_t *tls);
 
 #endif//TLSUV_TLS_LINK_H

--- a/include/tlsuv/tls_link.h
+++ b/include/tlsuv/tls_link.h
@@ -18,12 +18,15 @@
 
 typedef struct tls_link_s tls_link_t;
 typedef void (*tls_handshake_cb)(tls_link_t *l, int status);
-
+typedef struct ssl_buf_s ssl_buf_t;
 struct tls_link_s {
     UV_LINK_FIELDS
 
     tlsuv_engine_t engine;
     tls_handshake_cb hs_cb;
+
+    ssl_buf_t *ssl_in;  // buffer holding inbound ssl bytes
+    ssl_buf_t *ssl_out; // buffer holding outbound ssl_bytes
 };
 
 

--- a/sample/engine_test.c
+++ b/sample/engine_test.c
@@ -101,7 +101,7 @@ int main(int argc, char **argv) {
         printf("connected\n");
     }
 
-    engine->set_io_fd(engine, sock);
+    engine->set_io_fd(engine, (uv_os_sock_t)sock);
 
     // do handshake
     do {

--- a/sample/sample.c
+++ b/sample/sample.c
@@ -17,7 +17,8 @@
 #include <tlsuv/tlsuv.h>
 #include <uv.h>
 
-#define HOST "www.wttr.in"
+#define HOST "httpbingo.org"
+#define PATH "/json"
 
 static void alloc(uv_handle_t *handle, size_t suggested_size, uv_buf_t *buf) {
     buf->base = (char*) malloc(suggested_size);
@@ -64,7 +65,7 @@ void on_connect(uv_connect_t *cr, int status) {
     tlsuv_stream_read_start(mbed, alloc, on_data);
 
     uv_write_t *wr = malloc(sizeof(uv_write_t));
-    char req[] = "GET / HTTP/1.1\r\n"
+    char req[] = "GET " PATH " HTTP/1.1\r\n"
                  "Accept: */*\r\n"
                  "Connection: close\r\n"
                  "Host: " HOST "\r\n"

--- a/sample/um-curl.c
+++ b/sample/um-curl.c
@@ -28,10 +28,10 @@ struct app_ctx {
 static void do_request(uv_timer_t *t) {
     struct app_ctx *app = t->data;
 
-    tlsuv_http_req_t *r = tlsuv_http_req(&app->clt, "GET", app->path, resp_cb, NULL);
-    r->resp.body_cb = body_cb;
-
     if (app->count-- > 0) {
+        tlsuv_http_req_t *r = tlsuv_http_req(&app->clt, "GET", app->path, resp_cb, NULL);
+        r->resp.body_cb = body_cb;
+
         uv_timer_start(t, do_request, app->cycle * 1000, 0);
     } else {
         uv_close((uv_handle_t *) t, NULL);

--- a/src/http.c
+++ b/src/http.c
@@ -553,6 +553,7 @@ int tlsuv_http_init(uv_loop_t *l, tlsuv_http_t *clt, const char *url) {
     tcp_src_keepalive(src, 1, 3);
     int rc = tlsuv_http_init_with_src(l, clt, url, (tlsuv_src_t *) src);
     clt->own_src = true;
+    clt->tls_link = (tls_link_t){0};
     return rc;
 }
 
@@ -742,6 +743,7 @@ static void free_http(tlsuv_http_t *clt) {
         free(clt->src);
         clt->src = NULL;
     }
+    tlsuv_tls_link_free(&clt->tls_link);
 }
 
 int tlsuv_parse_url(struct tlsuv_url_s *url, const char *urlstr) {

--- a/src/http.c
+++ b/src/http.c
@@ -218,6 +218,7 @@ static void make_links(tlsuv_http_t *clt, uv_link_t *conn_src) {
             clt->engine->set_protocols(clt->engine, supported_alpn, supported_apln_num);
         }
 
+        tlsuv_tls_link_free(&clt->tls_link);
         tlsuv_tls_link_init(&clt->tls_link, clt->engine, on_tls_handshake);
         clt->tls_link.data = clt;
 

--- a/src/mbedtls/engine.c
+++ b/src/mbedtls/engine.c
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 
+#include <assert.h>
 #include <stdbool.h>
 #include <stdlib.h>
 #include <string.h>
@@ -24,6 +25,7 @@
 #include <mbedtls/entropy.h>
 #include <mbedtls/error.h>
 #include <mbedtls/base64.h>
+#include <mbedtls/net_sockets.h>
 #include <mbedtls/asn1.h>
 #include <mbedtls/asn1write.h>
 #include <mbedtls/oid.h>
@@ -84,8 +86,12 @@ struct mbedtls_engine {
     mbedtls_x509_crt *ca;
     mbedtls_ssl_context *ssl;
     mbedtls_ssl_session *session;
-    tlsuv_BIO *in;
-    tlsuv_BIO *out;
+
+    io_ctx io;
+    uv_os_fd_t io_fd;
+    io_read read_f;
+    io_write write_f;
+
     int error;
 
     int ip_len;
@@ -101,18 +107,21 @@ static int mbedtls_set_own_cert(tls_context *ctx, tlsuv_private_key_t key, tls_c
 
 tlsuv_engine_t new_mbedtls_engine(void *ctx, const char *host);
 
+static void mbedtls_set_io(tlsuv_engine_t, io_ctx pVoid, io_read pFunction, io_write pFunction1);
+static void mbedtls_set_fd(tlsuv_engine_t, uv_os_fd_t i1);
+
 static tls_handshake_state mbedtls_hs_state(tlsuv_engine_t engine);
 static tls_handshake_state
-mbedtls_continue_hs(tlsuv_engine_t engine, char *in, size_t in_bytes, char *out, size_t *out_bytes, size_t maxout);
+mbedtls_continue_hs(tlsuv_engine_t engine);
 
 static const char* mbedtls_get_alpn(tlsuv_engine_t engine);
 
-static int mbedtls_write(tlsuv_engine_t engine, const char *data, size_t data_len, char *out, size_t *out_bytes, size_t maxout);
+static int mbedtls_write(tlsuv_engine_t engine, const char *data, size_t data_len);
 
 static int
-mbedtls_read(tlsuv_engine_t engine, const char *ssl_in, size_t ssl_in_len, char *out, size_t *out_bytes, size_t maxout);
+mbedtls_read(tlsuv_engine_t engine, char *ssl_in, size_t *ssl_in_len, size_t out);
 
-static int mbedtls_close(tlsuv_engine_t engine, char *out, size_t *out_bytes, size_t maxout);
+static int mbedtls_close(tlsuv_engine_t engine);
 
 static int mbedtls_reset(tlsuv_engine_t engine);
 
@@ -158,23 +167,21 @@ static tls_context mbedtls_context_api = {
 };
 
 static struct tlsuv_engine_s mbedtls_engine_api = {
-    .set_protocols = mbedtls_set_alpn_protocols,
-    .handshake_state = mbedtls_hs_state,
-    .handshake = mbedtls_continue_hs,
-    .get_alpn = mbedtls_get_alpn,
-    .close = mbedtls_close,
-    .write = mbedtls_write,
-    .read = mbedtls_read,
-    .reset = mbedtls_reset,
-    .strerror = mbedtls_eng_error,
-    .free = mbedtls_free,
+        .set_io = mbedtls_set_io,
+        .set_io_fd = mbedtls_set_fd,
+        .set_protocols = mbedtls_set_alpn_protocols,
+        .handshake_state = mbedtls_hs_state,
+        .handshake = mbedtls_continue_hs,
+        .get_alpn = mbedtls_get_alpn,
+        .close = mbedtls_close,
+        .write = mbedtls_write,
+        .read = mbedtls_read,
+        .reset = mbedtls_reset,
+        .strerror = mbedtls_eng_error,
+        .free = mbedtls_free,
 };
 
 static void init_ssl_context(mbedtls_ssl_config *ssl_config, const char *ca, size_t cabuf_len);
-
-static int mbed_ssl_recv(void *ctx, uint8_t *buf, size_t len);
-
-static int mbed_ssl_send(void *ctx, const uint8_t *buf, size_t len);
 
 static const char* mbedtls_version(void) {
     return MBEDTLS_VERSION_STRING_FULL;
@@ -237,11 +244,13 @@ static void init_ssl_context(mbedtls_ssl_config *ssl_config, const char *cabuf, 
     if (cabuf != NULL) {
         int rc = cabuf_len > 0 ? mbedtls_x509_crt_parse(engine->ca, (const unsigned char *)cabuf, cabuf_len) : 0;
         if (rc < 0) {
-            UM_LOG(WARN, "mbedtls_engine: %s\n", mbedtls_error(rc));
+            UM_LOG(VERB, "mbedtls_engine: %s", mbedtls_error(rc));
             mbedtls_x509_crt_init(engine->ca);
 
             rc = mbedtls_x509_crt_parse_file(engine->ca, cabuf);
-            UM_LOG(WARN, "mbedtls_engine: %s\n", mbedtls_error(rc));
+            if (rc < 0) {
+                UM_LOG(WARN, "failed to load CA from file or memory: %s", mbedtls_error(rc));
+            }
         }
     } else { // try loading default CA stores
 #if _WIN32
@@ -375,9 +384,6 @@ tlsuv_engine_t new_mbedtls_engine(void *ctx, const char *host) {
 
     mbed_eng->api = mbedtls_engine_api;
     mbed_eng->ssl = ssl;
-    mbed_eng->in = tlsuv_BIO_new();
-    mbed_eng->out = tlsuv_BIO_new();
-    mbedtls_ssl_set_bio(ssl, mbed_eng, mbed_ssl_send, mbed_ssl_recv, NULL);
 
     mbedtls_ssl_set_verify(ssl, internal_cert_verify, mbed_eng);
 
@@ -468,7 +474,6 @@ static int mbedtls_verify_signature(void *cert, enum hash_algo md, const char* d
     return rc != 0 ? -1 : 0;
 }
 
-
 static void mbedtls_free_ctx(tls_context *ctx) {
     struct mbedtls_context *c = (struct mbedtls_context *)ctx;
     if (c->own_key) {
@@ -496,13 +501,14 @@ static int mbedtls_reset(tlsuv_engine_t engine) {
         free(e->session);
         e->session = NULL;
     }
+    e->io = NULL;
+    e->read_f = NULL;
+    e->write_f = NULL;
     return mbedtls_ssl_session_reset(e->ssl);
 }
 
 static void mbedtls_free(tlsuv_engine_t engine) {
     struct mbedtls_engine *e = (struct mbedtls_engine *)engine;
-    tlsuv_BIO_free(e->in);
-    tlsuv_BIO_free(e->out);
 
     mbedtls_ssl_free(e->ssl);
     if (e->ssl) {
@@ -622,6 +628,63 @@ static void tls_debug_f(void *ctx, int level, const char *file, int line, const 
     um_log(level, file, line, "%s", str);
 }
 
+static int engine_io_write(void *e, const unsigned char *data, size_t len) {
+    struct mbedtls_engine *eng = (struct mbedtls_engine *) e;
+    if (len > INT_MAX) {
+        len = INT_MAX;
+    }
+
+    ssize_t rc = eng->write_f(eng->io, (const char*)data, len);
+    if (rc < 0) {
+        if (rc == TLS_AGAIN) {
+            return MBEDTLS_ERR_SSL_WANT_WRITE;
+        }
+
+        if (rc == TLS_ERR) {
+            return MBEDTLS_ERR_NET_SEND_FAILED;
+        }
+    }
+    return (int)rc;
+}
+
+static int engine_io_read(void *e, unsigned char *buf, size_t max) {
+    struct mbedtls_engine *eng = (struct mbedtls_engine *) e;
+    if (max > INT_MAX) {
+        max = INT_MAX;
+    }
+
+    ssize_t rc = eng->read_f(eng->io, (char*)buf, max);
+
+    if (rc < 0) {
+        if (rc == TLS_AGAIN) {
+            return MBEDTLS_ERR_SSL_WANT_READ;
+        }
+
+        if (rc == TLS_ERR) {
+            return MBEDTLS_ERR_NET_RECV_FAILED;
+        }
+    }
+
+    return (int)rc;
+}
+
+static void mbedtls_set_io(tlsuv_engine_t e, io_ctx io, io_read read_f, io_write write_f) {
+    struct mbedtls_engine *eng = (struct mbedtls_engine *) e;
+    assert(eng->io == NULL);
+    eng->io = io;
+    eng->read_f = read_f;
+    eng->write_f = write_f;
+    mbedtls_ssl_set_bio(eng->ssl, eng, engine_io_write, engine_io_read, NULL);
+}
+
+static void mbedtls_set_fd(tlsuv_engine_t e, uv_os_fd_t fd) {
+    struct mbedtls_engine *eng = (struct mbedtls_engine *) e;
+    assert(eng->io == NULL);
+    eng->io_fd = fd;
+    eng->io = &eng->io_fd;
+    mbedtls_ssl_set_bio(eng->ssl, eng->io, mbedtls_net_send, mbedtls_net_recv, NULL);
+}
+
 static tls_handshake_state mbedtls_hs_state(tlsuv_engine_t engine) {
     struct mbedtls_engine *eng = (struct mbedtls_engine *) engine;
     switch (eng->ssl->MBEDTLS_PRIVATE(state)) {
@@ -637,11 +700,8 @@ static const char* mbedtls_get_alpn(tlsuv_engine_t engine) {
 }
 
 static tls_handshake_state
-mbedtls_continue_hs(tlsuv_engine_t engine, char *in, size_t in_bytes, char *out, size_t *out_bytes, size_t maxout) {
+mbedtls_continue_hs(tlsuv_engine_t engine) {
     struct mbedtls_engine *eng = (struct mbedtls_engine *) engine;
-    if (in_bytes > 0) {
-        tlsuv_BIO_put(eng->in, (const unsigned char *) in, in_bytes);
-    }
 
     if (eng->ssl->MBEDTLS_PRIVATE(state) == MBEDTLS_SSL_HELLO_REQUEST && eng->session) {
         mbedtls_ssl_set_session(eng->ssl, eng->session);
@@ -651,7 +711,6 @@ mbedtls_continue_hs(tlsuv_engine_t engine, char *in, size_t in_bytes, char *out,
     int state = mbedtls_ssl_handshake(eng->ssl);
     char err[1024];
     mbedtls_strerror(state, err, 1024);
-    *out_bytes = tlsuv_BIO_read(eng->out, (unsigned char *) out, maxout);
 
     if (eng->ssl->MBEDTLS_PRIVATE(state) == MBEDTLS_SSL_HANDSHAKE_OVER) {
         return TLS_HS_COMPLETE;
@@ -665,88 +724,75 @@ mbedtls_continue_hs(tlsuv_engine_t engine, char *in, size_t in_bytes, char *out,
     }
 }
 
-static int mbedtls_write(tlsuv_engine_t engine, const char *data, size_t data_len, char *out, size_t *out_bytes, size_t maxout) {
+static int mbedtls_write(tlsuv_engine_t engine, const char *data, size_t data_len) {
     struct mbedtls_engine *eng = (struct mbedtls_engine *) engine;
+    if (data_len > INT_MAX) {
+        data_len = INT_MAX;
+    }
+
+    int err = 0;
     size_t wrote = 0;
     while (data_len > wrote) {
         int rc = mbedtls_ssl_write(eng->ssl, (const unsigned char *)(data + wrote), data_len - wrote);
         if (rc < 0) {
-            eng->error = rc;
-            return rc;
+            err = rc;
+            break;
         }
         wrote += rc;
     }
-    *out_bytes = tlsuv_BIO_read(eng->out, (unsigned char *) out, maxout);
-    return (int) tlsuv_BIO_available(eng->out);
+
+    if (wrote > 0) {
+        return (int)wrote;
+    }
+
+    if (err == MBEDTLS_ERR_SSL_WANT_WRITE) {
+        return TLS_AGAIN;
+    }
+    return TLS_ERR;
 }
 
-static int
-mbedtls_read(tlsuv_engine_t engine, const char *ssl_in, size_t ssl_in_len, char *out, size_t *out_bytes, size_t maxout) {
+static int mbedtls_read(tlsuv_engine_t engine, char *out, size_t *out_bytes, size_t max) {
     struct mbedtls_engine *eng = (struct mbedtls_engine *) engine;
-    if (ssl_in_len > 0 && ssl_in != NULL) {
-        tlsuv_BIO_put(eng->in, (const unsigned char *) ssl_in, ssl_in_len);
-    }
 
     int rc;
     uint8_t *writep = (uint8_t*)out;
     size_t total_out = 0;
 
-    do {
-        rc = mbedtls_ssl_read(eng->ssl, writep, maxout - total_out);
-
-        if (rc > 0) {
-            total_out += rc;
-            writep += rc;
+    int err = 0;
+    while (max > total_out) {
+        rc = mbedtls_ssl_read(eng->ssl, writep, max - total_out);
+        if (rc < 0) {
+            if (rc == MBEDTLS_ERR_SSL_WANT_READ || rc == MBEDTLS_ERR_SSL_WANT_WRITE) {
+                err = TLS_AGAIN;
+            } else {
+                UM_LOG(ERR, "mbedTLS: %0x(%s)", rc, mbedtls_error(rc));
+                eng->error = rc;
+                err = TLS_ERR;
+            }
+            break;
         }
-    } while(rc > 0 && (maxout - total_out) > 0);
+        if (rc == 0) {
+            err = TLS_EOF;
+            break;
+        }
+
+        total_out += rc;
+        writep += rc;
+    }
+
+    if (total_out > 0) {
+        *out_bytes = total_out;
+        return mbedtls_ssl_get_bytes_avail(eng->ssl) > 0 ? TLS_MORE_AVAILABLE : TLS_OK;
+    }
 
     *out_bytes = total_out;
-
-    // this indicates that more bytes are needed to complete SSL frame
-    if (rc == MBEDTLS_ERR_SSL_WANT_READ) {
-        return tlsuv_BIO_available(eng->out) > 0 ? TLS_HAS_WRITE : TLS_OK;
-    }
-
-    if (rc == MBEDTLS_ERR_SSL_PEER_CLOSE_NOTIFY) {
-        return TLS_EOF;
-    }
-
-    if (rc < 0) {
-        eng->error = rc;
-        char err[1024];
-        mbedtls_strerror(rc, err, 1024);
-        UM_LOG(ERR, "mbedTLS: %0x(%s)", rc, err);
-        return TLS_ERR;
-    }
-
-    if (tlsuv_BIO_available(eng->in) > 0 || mbedtls_ssl_check_pending(eng->ssl)) {
-        return TLS_MORE_AVAILABLE;
-    }
-
-    return TLS_OK;
+    return err;
 }
 
-static int mbedtls_close(tlsuv_engine_t engine, char *out, size_t *out_bytes, size_t maxout) {
+static int mbedtls_close(tlsuv_engine_t engine) {
     struct mbedtls_engine *eng = (struct mbedtls_engine *) engine;
-    mbedtls_ssl_close_notify(eng->ssl); // TODO handle error
-
-    *out_bytes = tlsuv_BIO_read(eng->out, (unsigned char *) out, maxout);
+    mbedtls_ssl_close_notify(eng->ssl);
     return 0;
-}
-
-static int mbed_ssl_recv(void *ctx, uint8_t *buf, size_t len) {
-    struct mbedtls_engine *eng = ctx;
-    if (tlsuv_BIO_available(eng->in) == 0) {
-        return MBEDTLS_ERR_SSL_WANT_READ;
-    }
-
-    return tlsuv_BIO_read(eng->in, buf, len);
-}
-
-static int mbed_ssl_send(void *ctx, const uint8_t *buf, size_t len) {
-    struct mbedtls_engine *eng = ctx;
-    tlsuv_BIO_put(eng->out, buf, len);
-    return (int) len;
 }
 
 #define OID_PKCS7 MBEDTLS_OID_PKCS "\x07"

--- a/src/mbedtls/engine.c
+++ b/src/mbedtls/engine.c
@@ -345,6 +345,7 @@ static int internal_cert_verify(void *ctx, mbedtls_x509_crt *crt, int depth, uin
             UM_LOG(WARN, "failed to create Trust object: %s", err);
             CFRelease(error);
         }
+        CFRelease(x509policy);
         CFRelease(certs);
     }
 #endif

--- a/src/openssl/engine.c
+++ b/src/openssl/engine.c
@@ -670,7 +670,9 @@ static int tls_verify_signature(void *cert, enum hash_algo md, const char* data,
         unsigned long err = ERR_peek_error();
         UM_LOG(WARN, "no pub key: %ld/%s", err, ERR_lib_error_string(err));
     }
-    return verify_signature(pk, md, data, datalen, sig, siglen);
+    int rc = verify_signature(pk, md, data, datalen, sig, siglen);
+    EVP_PKEY_free(pk);
+    return rc;
 }
 
 static void tls_free_ctx(tls_context *ctx) {

--- a/src/openssl/engine.c
+++ b/src/openssl/engine.c
@@ -704,6 +704,8 @@ static int tls_reset(tlsuv_engine_t self) {
     struct openssl_engine *e = (struct openssl_engine *)self;
     ERR_clear_error();
 
+    e->bio = NULL;
+
     if (!SSL_clear(e->ssl)) {
         int err = SSL_get_error(e->ssl, 0);
         UM_LOG(ERR, "error resetting TSL enging: %d(%s)", err, tls_error(err));

--- a/src/openssl/engine.c
+++ b/src/openssl/engine.c
@@ -578,13 +578,6 @@ tlsuv_engine_t new_openssl_engine(void *ctx, const char *host) {
     engine->api = openssl_engine_api;
 
     engine->ssl = SSL_new(context->ctx);
-//    engine->in = BIO_new(BIO_s_mem());
-//    engine->out = BIO_new(BIO_s_mem());
-//
-//    BIO *engine_bio = BIO_new(BIO_s_engine());
-//    BIO_set_data(engine_bio, engine);
-//    BIO_set_init(engine_bio, 1);
-//    SSL_set_bio(engine->ssl, engine_bio, engine_bio);
 
     SSL_set_tlsext_host_name(engine->ssl, host);
     SSL_set1_host(engine->ssl, host);
@@ -613,7 +606,7 @@ static void set_io_fd(tlsuv_engine_t self, uv_os_fd_t fd) {
     struct openssl_engine *e = (struct openssl_engine *) self;
     assert(e->bio == NULL);
 
-    e->bio = BIO_new_fd(fd, false);
+    e->bio = BIO_new_socket(fd, false);
     SSL_set_bio(e->ssl, e->bio, e->bio);
 }
 
@@ -850,6 +843,7 @@ static tls_handshake_state tls_hs_state(tlsuv_engine_t engine) {
 
 static int print_err_cb(const char *e, size_t len, void* v) {
     UM_LOG(WARN, "%.*s", (int)len, e);
+    return 1;
 }
 
 static tls_handshake_state

--- a/src/tls_link.c
+++ b/src/tls_link.c
@@ -18,6 +18,7 @@
 #include "tlsuv/tls_link.h"
 #include "um_debug.h"
 #include "util.h"
+#include <string.h>
 
 static int tls_read_start(uv_link_t *l);
 static void tls_alloc(uv_link_t *l, size_t suggested, uv_buf_t *buf);
@@ -36,7 +37,7 @@ static const uv_link_methods_t tls_methods = {
     .read_cb_override = tls_read_cb
 };
 
-#define TLS_BUF_SZ (32 * 1024)
+#define TLS_BUF_SZ (64 * 1024)
 WRAPAROUND_BUFFER(ssl_buf_s, TLS_BUF_SZ);
 
 void tls_alloc(uv_link_t *l, size_t suggested, uv_buf_t *buf) {
@@ -295,4 +296,13 @@ int tlsuv_tls_link_init(tls_link_t *tls, tlsuv_engine_t engine, tls_handshake_cb
     engine->set_io(engine, tls, tls_link_io_read, tls_link_io_write);
     tls->hs_cb = cb;
     return 0;
+}
+
+void tlsuv_tls_link_free(tls_link_t *tls) {
+    if (tls) {
+        free(tls->ssl_out);
+        tls->ssl_out = NULL;
+        free(tls->ssl_in);
+        tls->ssl_in = NULL;
+    }
 }

--- a/src/tls_link.c
+++ b/src/tls_link.c
@@ -221,7 +221,7 @@ static void tls_link_flush_io(tls_link_t *tls, uv_link_write_cb cb, void *ctx) {
         WAB_GET_SPACE(*tls->ssl_out, p, len);
     }
     if (req) {
-        UM_LOG(TRACE, "flushing %zd bytes", len);
+        UM_LOG(TRACE, "flushing %zd bytes", total);
         uv_buf_t b = uv_buf_init(req->b, total);
         req->cb = cb;
         req->ctx = ctx;

--- a/src/tls_link.c
+++ b/src/tls_link.c
@@ -17,6 +17,7 @@
 #include <tlsuv/tls_engine.h>
 #include "tlsuv/tls_link.h"
 #include "um_debug.h"
+#include "util.h"
 
 static int tls_read_start(uv_link_t *l);
 static void tls_alloc(uv_link_t *l, size_t suggested, uv_buf_t *buf);
@@ -24,6 +25,7 @@ static void tls_read_cb(uv_link_t *link, ssize_t nread, const uv_buf_t *buf);
 static int tls_write(uv_link_t *link, uv_link_t *source, const uv_buf_t bufs[],
                      unsigned int nbufs, uv_stream_t *send_handle, uv_link_write_cb cb, void *arg);
 static void tls_close(uv_link_t *link, uv_link_t *source, uv_link_close_cb cb);
+static void tls_link_flush_io(tls_link_t *, uv_link_write_cb , void *);
 
 static const uv_link_methods_t tls_methods = {
     .close = tls_close,
@@ -34,49 +36,14 @@ static const uv_link_methods_t tls_methods = {
     .read_cb_override = tls_read_cb
 };
 
-typedef struct tls_link_write_s {
-    char *tls_buf;
-    uv_link_write_cb cb;
-    void *ctx;
-
-} tls_link_write_t;
-
-static const int TLS_BUF_SZ = 32 * 1024;
+#define TLS_BUF_SZ (32 * 1024)
+WRAPAROUND_BUFFER(ssl_buf_s, TLS_BUF_SZ);
 
 void tls_alloc(uv_link_t *l, size_t suggested, uv_buf_t *buf) {
     tls_link_t *tls_link = (tls_link_t *) l;
-    tls_handshake_state st = tls_link->engine->handshake_state(tls_link->engine);
-    switch (st) {
-        case TLS_HS_BEFORE:
-        case TLS_HS_CONTINUE:
-            buf->base = malloc(suggested);
-            buf->len = suggested;
-            break;
-        case TLS_HS_COMPLETE:
-            uv_link_propagate_alloc_cb(l, suggested, buf);
-            break;
-        default:
-            UM_LOG(ERR, "TLS(%p) in bad state", tls_link);
-            break;
-    }
-}
 
-static void tls_write_free_cb(uv_link_t *source, int status, void *arg) {
-    if (arg)
-        free(arg);
-}
-
-static void tls_write_cb(uv_link_t *source, int status, void *arg) {
-    tls_link_write_t *wr = arg;
-    uv_link_t *tls_link = source->child;
-    if (wr->cb) {
-        wr->cb(tls_link, status, wr->ctx);
-    }
-
-    if (wr->tls_buf) {
-        free(wr->tls_buf);
-    }
-    free(wr);
+    WAB_PUT_SPACE(*tls_link->ssl_in, buf->base, buf->len);
+    UM_LOG(INFO, "allocated %zd", buf->len);
 }
 
 static int tls_read_start(uv_link_t *l) {
@@ -88,36 +55,37 @@ static int tls_read_start(uv_link_t *l) {
         UM_LOG(TRACE, "TLS(%p) is in the middle of handshake, resetting", tls);
         if (tls->engine->reset) {
             tls->engine->reset(tls->engine);
+
         }
     }
 
     uv_link_default_read_start(l);
 
-    uv_buf_t buf;
-    buf.base = malloc(TLS_BUF_SZ);
-    st = tls->engine->handshake(tls->engine, NULL, 0, buf.base, &buf.len,
-                                                         TLS_BUF_SZ);
-    UM_LOG(TRACE, "TLS(%p) starting handshake(sending %zd bytes, st = %d)", tls, buf.len, st);
+    st = tls->engine->handshake(tls->engine);
+    UM_LOG(TRACE, "TLS(%p) started handshake(st = %d)", tls, st);
+    tls_link_flush_io(tls, NULL, NULL);
 
-    tls_link_write_t *wr = calloc(1, sizeof(tls_link_write_t));
-    wr->tls_buf = buf.base;
-    return uv_link_propagate_write(l->parent, l, &buf, 1, NULL, tls_write_cb, wr);
+    return 0;
 }
 
 static void tls_read_cb(uv_link_t *l, ssize_t nread, const uv_buf_t *b) {
     tls_link_t *tls = (tls_link_t *) l;
-
     tls_handshake_state hs_state = tls->engine->handshake_state(tls->engine);
-    UM_LOG(TRACE, "TLS(%p)[%d]: %zd", tls, hs_state, nread);
+    UM_LOG(INFO, "TLS(%p)[%d]: %zd", tls, hs_state, nread);
 
-    if (nread < 0) {
+    if (nread >= 0) {
+        WAB_UPDATE_PUT(*tls->ssl_in, nread);
+    } else if (nread == UV_ENOBUFS) {
+        // our ssl buf is full
+    } else {
         UM_LOG(ERR, "TLS read %zd(%s)", nread, uv_strerror((int)nread));
         if (hs_state == TLS_HS_CONTINUE) {
             tls->engine->reset(tls->engine);
             tls->hs_cb(tls, TLS_HS_ERROR);
-            free(b->base);
         } else {
-            uv_link_propagate_read_cb(l, nread, b);
+            uv_buf_t buf;
+            uv_link_propagate_alloc_cb(l, TLS_BUF_SZ, &buf);
+            uv_link_propagate_read_cb(l, nread, &buf);
         }
         return;
     }
@@ -129,30 +97,13 @@ static void tls_read_cb(uv_link_t *l, ssize_t nread, const uv_buf_t *b) {
         }
 
         UM_LOG(TRACE, "TLS(%p) continuing handshake(%zd bytes received)", tls, nread);
-        uv_buf_t buf;
-        buf.base = malloc(TLS_BUF_SZ);
-        tls_handshake_state st =
-                tls->engine->handshake(tls->engine, b->base, nread, buf.base, &buf.len, TLS_BUF_SZ);
-
-        UM_LOG(TRACE, "TLS(%p) continuing handshake(sending %zd bytes, st = %d)", tls, buf.len, st);
-        if (buf.len > 0) {
-            tls_link_write_t *wr = calloc(1, sizeof(tls_link_write_t));
-            wr->tls_buf = buf.base;
-            int rc = uv_link_propagate_write(l->parent, l, &buf, 1, NULL, tls_write_cb, wr);
-            if (rc != 0) {
-                UM_LOG(WARN, "TLS(%p) failed to write during handshake %d(%s)", tls, rc, uv_strerror(rc));
-                tls_write_cb(l->parent, rc, wr);
-            }
-        }
-        else {
-            free(buf.base);
-        }
+        tls_handshake_state st = tls->engine->handshake(tls->engine);
+        tls_link_flush_io(tls, NULL, NULL);
 
         if (st == TLS_HS_COMPLETE) {
             UM_LOG(TRACE, "TLS(%p) handshake completed", tls);
             tls->hs_cb(tls, TLS_HS_COMPLETE);
-        }
-        else if (st == TLS_HS_ERROR) {
+        } else if (st == TLS_HS_ERROR) {
             const char *err = NULL;
             if (tls->engine->strerror) {
                 err = tls->engine->strerror(tls->engine);
@@ -161,105 +112,71 @@ static void tls_read_cb(uv_link_t *l, ssize_t nread, const uv_buf_t *b) {
             tls->hs_cb(tls, st);
             uv_link_propagate_read_cb(l, UV_ECONNABORTED, NULL);
         }
-        if (b->base) free(b->base);
     } else if (hs_state == TLS_HS_COMPLETE) {
         UM_LOG(TRACE, "TLS(%p) processing %zd bytes", tls, nread);
 
-        size_t bufsize = b->len;
-        char *inptr = b->base;
-        size_t inlen = nread;
         enum TLS_RESULT rc = TLS_MORE_AVAILABLE;
-        while(rc == TLS_MORE_AVAILABLE || rc == TLS_READ_AGAIN) {
-            ssize_t out_bytes = 0;
-            rc = tls->engine->read(tls->engine, inptr, inlen, b->base, (size_t *)&out_bytes, b->len);
-            UM_LOG(TRACE, "TLS(%p) produced %zd application byte (rc=%d)", tls, out_bytes, rc);
+        while(rc == TLS_MORE_AVAILABLE) {
+            uv_buf_t buf;
+            uv_link_propagate_alloc_cb(l, 64 * 1024, &buf);
 
-            switch (rc) {
-                case TLS_OK: {
-                    uv_link_propagate_read_cb(l, out_bytes, b);
-                    break;
-                }
-                case TLS_EOF: {
-                    if (out_bytes > 0) {
-                        uv_link_propagate_read_cb(l, out_bytes, b);
-                        uv_link_propagate_alloc_cb(l, bufsize, (uv_buf_t *)b);
-                    }
-                    uv_link_propagate_read_cb(l, UV_EOF, b);
-                    break;
-                }
-                case TLS_READ_AGAIN:
-                case TLS_MORE_AVAILABLE: {
-                    uv_link_propagate_read_cb(l, out_bytes, b);
-                    inlen = 0;
-                    inptr = NULL;
-                    uv_link_propagate_alloc_cb(l, bufsize, (uv_buf_t *)b);
-                    if (b->base == NULL || b->len == 0) {
-                        uv_link_propagate_read_cb(l, UV_ENOBUFS, b);
-                        return;
-                    }
-                    break;
-                }
-                case TLS_HAS_WRITE: {
-                    uv_buf_t buf;
-                    buf.base = malloc(TLS_BUF_SZ);
-                    tls->engine->write(tls->engine, NULL, 0, buf.base, &buf.len, TLS_BUF_SZ);
-                    uv_link_propagate_write(l->parent, l, &buf, 1, NULL, tls_write_free_cb, buf.base);
-                    break;
-                }
-                case TLS_ERR:
-                default:
-                    if (out_bytes > 0) {
-                        uv_link_propagate_read_cb(l, out_bytes, b);
-                        uv_link_propagate_alloc_cb(l, bufsize, (uv_buf_t*)b);
-                    }
-                    if (rc != TLS_ERR) {
-                        UM_LOG(ERR, "aborting after unexpected TLS engine result: %d", rc);
-                    } else {
-                        UM_LOG(ERR, "aborting after TLS engine error: %s", tls->engine->strerror(tls->engine));
-                    }
-                    uv_link_propagate_read_cb(l, UV_ECONNABORTED, b);
-                    break;
+            if (buf.base == NULL || buf.len == 0) {
+                uv_link_propagate_read_cb(l, UV_ENOBUFS, &buf);
+                break;
+            }
+
+            size_t read_len;
+            rc = tls->engine->read(tls->engine, buf.base, (size_t *)&read_len, buf.len);
+            UM_LOG(INFO, "TLS(%p) produced %zd application byte (rc=%d)", tls, read_len, rc);
+
+            if (read_len > 0) {
+                uv_link_propagate_read_cb(l, (ssize_t)read_len, &buf);
+                continue;
+            }
+
+            if (rc == TLS_AGAIN) {
+                uv_link_propagate_read_cb(l, 0, &buf);
+            } else if (rc == TLS_EOF) {
+                uv_link_propagate_read_cb(l, UV_EOF, &buf);
+            } else if (rc == TLS_ERR) {
+                uv_link_propagate_read_cb(l, UV_ECONNABORTED, &buf);
+            } else {
+                UM_LOG(ERR, "aborting after unexpected TLS engine result: %d", rc);
+                uv_link_propagate_read_cb(l, UV_ECONNABORTED, &buf);
             }
         }
-    }
-    else {
-        UM_LOG(VERB, "hs_state = %d", hs_state);
+    } else {
+        UM_LOG(WARN, "SHOULD NOT BE here hs_state = %d", hs_state);
     }
 }
 
 static int tls_write(uv_link_t *l, uv_link_t *source, const uv_buf_t bufs[],
                      unsigned int nbufs, uv_stream_t *send_handle, uv_link_write_cb cb, void *arg) {
     tls_link_t *tls = (tls_link_t *) l;
-    uv_buf_t buf = uv_buf_init(NULL, 0);
-    int tls_rc = 0;
-    for (int i = 0; i < nbufs; i++) {
-        tls_rc = tls->engine->write(tls->engine, bufs[i].base, bufs[i].len, NULL, &buf.len, 0);
-        if (tls_rc < 0) {
-            UM_LOG(ERR, "TLS(%p) engine failed to wrap: %d(%s)", tls, tls_rc, tls->engine->strerror(tls->engine));
-            free(buf.base);
-            return tls_rc;
-        }
-    }
-    
 
-    if (tls_rc > 0) {
-        buf.base = malloc(tls_rc);
-        tls_rc = tls->engine->write(tls->engine, NULL, 0, buf.base, &buf.len, tls_rc);
-        if (tls_rc < 0) {
-            UM_LOG(ERR, "TLS(%p) engine failed to wrap: %d(%s)", tls, tls_rc, tls->engine->strerror(tls->engine));
-            free(buf.base);
-            return tls_rc;
+    int tls_rc;
+    int i = 0;
+    while(i < nbufs) {
+        uv_buf_t b = bufs[i];
+        while(b.len > 0) {
+            tls_rc = tls->engine->write(tls->engine, b.base, b.len);
+            if (tls_rc < 0) {
+                goto error;
+            }
+            b.base += tls_rc;
+            b.len -= tls_rc;
         }
-    } else if (tls_rc == 0) { // nothing to send
-        tls_write_cb(l, 0, arg);
-        return 0;
+        i++;
     }
-    
-    tls_link_write_t *wr = calloc(1, sizeof(tls_link_write_t));
-    wr->tls_buf = buf.base;
-    wr->cb = cb;
-    wr->ctx = arg;
-    return uv_link_propagate_write(l->parent, l, &buf, 1, send_handle, tls_write_cb, wr);
+
+    // make sure callback is called after the last SSL bytes are put on the wire
+    tls_link_flush_io(tls, cb, arg);
+    return 0;
+
+    error:
+    UM_LOG(ERR, "TLS(%p) engine failed to wrap: %d(%s)", tls, tls_rc, tls->engine->strerror(tls->engine));
+    cb(l, tls_rc, arg);
+    return tls_rc;
 }
 
 static void tls_close(uv_link_t *l, uv_link_t *source, uv_link_close_cb close_cb) {
@@ -271,9 +188,110 @@ static void tls_close(uv_link_t *l, uv_link_t *source, uv_link_close_cb close_cb
     close_cb(source);
 }
 
+struct flush_req {
+    char *b;
+    uv_link_write_cb cb;
+    void *ctx;
+};
+
+static void tls_link_io_write_cb(uv_link_t *l, int status, void *data) {
+    struct flush_req *req = data;
+    if (req->cb) {
+        req->cb(l, status, req->ctx);
+    }
+    free(req->b);
+    free(req);
+}
+
+static void tls_link_flush_io(tls_link_t *tls, uv_link_write_cb cb, void *ctx) {
+    struct flush_req *req = NULL;
+    char *p;
+    size_t len;
+    size_t total = 0;
+    WAB_GET_SPACE(*tls->ssl_out, p, len);
+    while (len > 0) {
+        if (req == NULL) {
+            req = calloc(1, sizeof(struct flush_req));
+            req->b = malloc(TLS_BUF_SZ);
+        }
+        UM_LOG(INFO, "writing %zd bytes", len);
+        memcpy(req->b + total, p, len);
+        total += len;
+        WAB_UPDATE_GET(*tls->ssl_out, len);
+        WAB_GET_SPACE(*tls->ssl_out, p, len);
+    }
+    if (req) {
+        uv_buf_t b = uv_buf_init(req->b, total);
+        req->cb = cb;
+        req->ctx = ctx;
+        uv_link_propagate_write(tls->parent, (uv_link_t *) tls, &b, 1, NULL, tls_link_io_write_cb, req);
+    } else {
+        // this should not happen but just in case
+        if (cb) {
+            cb((uv_link_t *) tls, 0, ctx);
+        }
+    }
+    // ssl_out get caught up to put, just reset it
+    WAB_INIT(*tls->ssl_out);
+}
+
+static ssize_t tls_link_io_write(io_ctx ctx, const char *data, size_t data_len) {
+    tls_link_t *tls = ctx;
+    if (data_len > INT_MAX) {
+        data_len = INT_MAX;
+    }
+    UM_LOG(INFO, "io buffering %zd bytes", data_len);
+    size_t ret = data_len;
+    while (data_len > 0) {
+        char *sslp;
+        size_t len;
+        WAB_PUT_SPACE(*tls->ssl_out, sslp, len);
+
+        if (len == 0) {
+            tls_link_flush_io(tls, NULL, NULL);
+        }
+
+        if (len > data_len) {
+            len = data_len;
+        }
+        memcpy(sslp, data, len);
+        WAB_UPDATE_PUT(*tls->ssl_out, len);
+        data += len;
+        data_len -= len;
+    }
+
+    return (ssize_t) ret;
+}
+
+static ssize_t tls_link_io_read(io_ctx ctx, char *data, size_t max) {
+    tls_link_t *tls = ctx;
+    char *ssl_p;
+    size_t avail;
+    WAB_GET_SPACE(*tls->ssl_in, ssl_p, avail);
+    if (avail == 0) {
+        return TLS_AGAIN;
+    }
+
+    if (max > avail) {
+        max = avail;
+    }
+
+    memcpy(data, ssl_p, max);
+    WAB_UPDATE_GET(*tls->ssl_in, max);
+    UM_LOG(INFO, "read %zd/%zd bytes", max, avail);
+
+    return (ssize_t)max;
+}
+
 int tlsuv_tls_link_init(tls_link_t *tls, tlsuv_engine_t engine, tls_handshake_cb cb) {
     uv_link_init((uv_link_t *) tls, &tls_methods);
     tls->engine = engine;
+    tls->ssl_in = malloc(sizeof(ssl_buf_t));
+    WAB_INIT(*tls->ssl_in);
+    tls->ssl_out = malloc(sizeof(ssl_buf_t));
+    WAB_INIT(*tls->ssl_out);
+
+    engine->set_io(engine, tls, tls_link_io_read, tls_link_io_write);
     tls->hs_cb = cb;
     return 0;
 }

--- a/src/tlsuv.c
+++ b/src/tlsuv.c
@@ -255,6 +255,8 @@ int tlsuv_stream_free(tlsuv_stream_t *clt) {
         free(clt->socket);
         clt->socket = NULL;
     }
+    tlsuv_tls_link_free(&clt->tls_link);
+
     return 0;
 }
 

--- a/src/util.h
+++ b/src/util.h
@@ -24,6 +24,7 @@
  * get space for putting bytes into the buffer
  */
 #define WAB_PUT_SPACE(b,p,l) do{ \
+if ((b).putp == (b).buf + sizeof((b).buf) && (b).getp != (b).buf) (b).putp = (b).buf; \
 p = (b).putp;                                 \
 if ((b).putp >= (b).getp) l = (b).buf + sizeof((b).buf) - (b).putp; \
 else l = (b).getp - (b).putp - 1; \
@@ -35,7 +36,7 @@ else l = (b).getp - (b).putp - 1; \
 #define WAB_UPDATE_PUT(b,l) do { \
 wab_check_bounds((b), (b).putp + l);                              \
 (b).putp += l;                     \
-if ((b).putp - (b).buf == sizeof((b).buf)) (b).putp = (b).buf; \
+if ((b).putp - (b).buf == sizeof((b).buf) && (b).getp != (b).buf) (b).putp = (b).buf; \
 } while(0)
 
 /**
@@ -51,9 +52,10 @@ else l = (b).buf + sizeof((b).buf) - (b).getp; \
 /**
  * update read pointer
  */
-#define WAB_UPDATE_GET(b,l) do { \
+#define WAB_UPDATE_GET(b, l) do { \
 wab_check_bounds((b), (b).getp + l);                              \
-(b).getp += l;                     \
+(b).getp += l;                   \
+if ((b).getp == (b).putp) (b).getp = (b).putp = (b).buf; \
 if ((b).getp == (b).buf + sizeof((b).buf)) (b).getp = (b).buf; \
 } while(0)
 

--- a/src/util.h
+++ b/src/util.h
@@ -1,0 +1,60 @@
+//
+// Created by Eugene Kobyakov on 11/3/23.
+//
+
+#ifndef TLSUV_UTIL_H
+#define TLSUV_UTIL_H
+
+#include <assert.h>
+
+/**
+ * wrap-around buffer
+ */
+#define WRAPAROUND_BUFFER(name, size) struct name { \
+    char *putp;                          \
+    char *getp;                          \
+    char buf[size];\
+}
+
+#define wab_check_bounds(b, p) assert((p) >= (b).buf && (p) <= (b).buf + sizeof((b).buf))
+
+#define WAB_INIT(b) do { (b).getp = (b).putp = (b).buf; } while(0)
+
+/**
+ * get space for putting bytes into the buffer
+ */
+#define WAB_PUT_SPACE(b,p,l) do{ \
+p = (b).putp;                                 \
+if ((b).putp >= (b).getp) l = (b).buf + sizeof((b).buf) - (b).putp; \
+else l = (b).getp - (b).putp - 1; \
+} while(0)
+
+/**
+ * update buffer's put pointer
+ */
+#define WAB_UPDATE_PUT(b,l) do { \
+wab_check_bounds((b), (b).putp + l);                              \
+(b).putp += l;                     \
+if ((b).putp - (b).buf == sizeof((b).buf)) (b).putp = (b).buf; \
+} while(0)
+
+/**
+ * get pointer and available bytes for reading from buffer
+ */
+#define WAB_GET_SPACE(b,p,l) do { \
+p = (b).getp;                       \
+if ((b).getp <= (b).putp) l = (b).putp - (b).getp; \
+else l = (b).buf + sizeof((b).buf) - (b).getp; \
+} while(0)
+
+
+/**
+ * update read pointer
+ */
+#define WAB_UPDATE_GET(b,l) do { \
+wab_check_bounds((b), (b).getp + l);                              \
+(b).getp += l;                     \
+if ((b).getp == (b).buf + sizeof((b).buf)) (b).getp = (b).buf; \
+} while(0)
+
+#endif //TLSUV_UTIL_H

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -49,6 +49,7 @@ set(test_srcs
 add_executable(all_tests
         all_tests.cpp ${test_srcs})
 set_property(TARGET all_tests PROPERTY CXX_STANDARD 20)
+target_include_directories(all_tests PRIVATE ../src)
 target_compile_options(all_tests PRIVATE ${PKCS11_OPTS})
 target_compile_definitions(all_tests PRIVATE TEST_DATA_DIR=${CMAKE_CURRENT_BINARY_DIR}/testdata)
 

--- a/tests/engine_tests.cpp
+++ b/tests/engine_tests.cpp
@@ -202,7 +202,7 @@ TEST_CASE("ALPN negotiation", "[engine]") {
         perror("failed to conenct");
     }
 
-    engine->set_io_fd(engine, sock);
+    engine->set_io_fd(engine, (uv_os_fd_t)sock);
 
     // do handshake
     do {

--- a/tests/engine_tests.cpp
+++ b/tests/engine_tests.cpp
@@ -188,13 +188,12 @@ TEST_CASE("ALPN negotiation", "[engine]") {
         "http1.1"
     };
     int num_protos = sizeof(protos)/sizeof(*protos);
-//    tls->api->set_alpn_protocols(tls->ctx, protos, 2);
     tlsuv_engine_t engine = tls->new_engine(tls, host);
     engine->set_protocols(engine, protos, num_protos);
 
     SOCKET sock = socket(addr->ai_family, SOCK_STREAM, 0);
 
-    struct sockaddr_in *address = reinterpret_cast<sockaddr_in *>(addr->ai_addr);
+    auto address = reinterpret_cast<sockaddr_in *>(addr->ai_addr);
     int addrlen = addr->ai_addrlen;
 
     printf("sin_family = %d, %s:%d \n", address->sin_family, inet_ntoa(address->sin_addr), htons(address->sin_port));
@@ -203,14 +202,11 @@ TEST_CASE("ALPN negotiation", "[engine]") {
         perror("failed to conenct");
     }
 
-    // do handshake
-    char ssl_in[32 * 1024];
-    char ssl_out[32 * 1024];
-    size_t in_bytes = 0;
-    size_t out_bytes = 0;
+    engine->set_io_fd(engine, sock);
 
+    // do handshake
     do {
-        tls_handshake_state state = engine->handshake(engine, ssl_in, in_bytes, ssl_out, &out_bytes, sizeof(ssl_out));
+        tls_handshake_state state = engine->handshake(engine);
 
         REQUIRE(state != TLS_HS_ERROR);
 
@@ -219,22 +215,12 @@ TEST_CASE("ALPN negotiation", "[engine]") {
             break;
         }
 
-        if (out_bytes > 0) {
-            printf("hs: out bytes = %zd\n", out_bytes);
-            send(sock, ssl_out, out_bytes, 0);
-        }
-
-        in_bytes = recv(sock, ssl_in, sizeof(ssl_in), 0);
-        printf("hs: in bytes = %zd\n", in_bytes);
-
     } while (true);
 
     const char *alpn = engine->get_alpn(engine);
     CHECK_THAT(alpn, Catch::Matches("h2"));
 
-    rc = engine->close(engine, ssl_out, &out_bytes, sizeof(ssl_out));
-    if (rc == 0 && out_bytes > 0)
-        send(sock, ssl_out, out_bytes, 0);
+    engine->close(engine);
 
 #if _WIN32
     closesocket(sock);


### PR DESCRIPTION
this reduces the memory footprint of TLS processing, in some cases to nearly zero-copy

