### PR TITLE
HTTP form request

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -50,12 +50,12 @@ jobs:
     - name: start test server
       if: matrix.os != 'windows'
       run: |
-        ${{ github.workspace }}/build/test-server -keyfile ./tests/certs/server.key -certfile ./tests/certs/server.crt &
+        ${{ github.workspace }}/build/test-server -ca-key ./tests/certs/ca.key -ca ./tests/certs/ca.pem &
 
     - name: start test server
       if: matrix.os == 'windows'
       run: |
-        Start-Process -FilePath ${{ github.workspace }}/build/test-server -ArgumentList "-keyfile","./tests/certs/server.key","-certfile","./tests/certs/server.crt"
+        Start-Process -FilePath ${{ github.workspace }}/build/test-server -ArgumentList "-ca-key","./tests/certs/ca.key","-ca","./tests/certs/ca.pem"
 
     - uses: lukka/run-cmake@v10
       name: Build and Test

--- a/include/tlsuv/http.h
+++ b/include/tlsuv/http.h
@@ -295,6 +295,10 @@ int tlsuv_http_req_data(tlsuv_http_req_t *req, const char *body, size_t bodylen,
  * Convenience method to send a form request. Can only be done once.
  * set request's `Content-Type` to `application/x-www-form-urlencoded`
  * and encodes the form values into the body of the request.
+ *
+ * Form size is limited to 16K encoded bytes. If that size is exceeded UV_ENOMEM is returned
+ * and request is cancelled (request callback is called with appropriate error code/message)
+ *
  * @param req
  * @param count number of name/value pairs
  * @param pairs name/value pairs

--- a/include/tlsuv/http.h
+++ b/include/tlsuv/http.h
@@ -62,7 +62,7 @@ typedef void (*tlsuv_http_resp_cb)(tlsuv_http_resp_t *resp, void *ctx);
 /**
  * HTTP body callback type.
  */
-typedef void (*tlsuv_http_body_cb)(tlsuv_http_req_t *req, const char *body, ssize_t len);
+typedef void (*tlsuv_http_body_cb)(tlsuv_http_req_t *req, char *body, ssize_t len);
 
 typedef void (*tlsuv_http_close_cb)(tlsuv_http_t *);
 /**
@@ -156,6 +156,11 @@ struct tlsuv_http_s {
     void *data;
     tlsuv_http_close_cb close_cb;
 };
+
+typedef struct tlsuv_http_pair {
+    const char *name;
+    const char *value;
+} tlsuv_http_pair;
 
 /**
  * Initialize HTTP client
@@ -285,6 +290,17 @@ int tlsuv_http_req_header(tlsuv_http_req_t *req, const char *name, const char *v
  * @return
  */
 int tlsuv_http_req_data(tlsuv_http_req_t *req, const char *body, size_t bodylen, tlsuv_http_body_cb cb);
+
+/**
+ * Convenience method to send a form request. Can only be done once.
+ * set request's `Content-Type` to `application/x-www-form-urlencoded`
+ * and encodes the form values into the body of the request.
+ * @param req
+ * @param count number of name/value pairs
+ * @param pairs name/value pairs
+ * @return 0 for success, or error code
+ */
+int tlsuv_http_req_form(tlsuv_http_req_t *req, size_t count, const tlsuv_http_pair pairs[]);
 
 /**
  * Indicate the end of the request body. Only needed if `Transfer-Encoding` header was set to `chunked`

--- a/src/http_req.h
+++ b/src/http_req.h
@@ -18,11 +18,13 @@
 #include <tlsuv/http.h>
 
 void http_req_init(tlsuv_http_req_t *req, const char *method, const char *path);
+int http_req_cancel_err(tlsuv_http_t *clt, tlsuv_http_req_t *req, int error, const char *msg);
+
 void http_req_free(tlsuv_http_req_t *r);
 ssize_t http_req_process(tlsuv_http_req_t *req, const char* buf, ssize_t len);
 
 // write request header
-size_t http_req_write(tlsuv_http_req_t *req, char *buf, size_t maxlen);
+ssize_t http_req_write(tlsuv_http_req_t *req, char *buf, size_t maxlen);
 
 void free_hdr_list(um_header_list *l);
 void set_http_header(um_header_list *hl, const char* name, const char *value);

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -3,6 +3,8 @@ ENABLE_LANGUAGE(CXX)
 find_package(Catch2 CONFIG REQUIRED)
 message("catch2 is ${Catch2_CONFIG}")
 
+find_package(parson CONFIG REQUIRED)
+
 FILE(COPY ${CMAKE_CURRENT_SOURCE_DIR}/testdata DESTINATION ${CMAKE_CURRENT_BINARY_DIR}/ )
 CONFIGURE_FILE(softhsm2.conf.in ${CMAKE_CURRENT_BINARY_DIR}/softhsm2.conf)
 
@@ -67,6 +69,7 @@ endif (softhsm_lib)
 target_link_libraries(all_tests
         tlsuv
         Catch2::Catch2
+        parson::parson
         )
 
 target_include_directories(all_tests PRIVATE ../src)

--- a/tests/http_tests.cpp
+++ b/tests/http_tests.cpp
@@ -26,6 +26,8 @@ limitations under the License.
 #include <tlsuv/tls_engine.h>
 #include <tlsuv/tlsuv.h>
 
+#include <parson.h>
+
 extern tlsuv_log_func test_log;
 using namespace std;
 using namespace Catch::Matchers;
@@ -107,13 +109,13 @@ public:
     uv_timeval64_t resp_endtime{};
 };
 
-void req_body_cb(tlsuv_http_req_t *req, const char *chunk, ssize_t status) {
+void req_body_cb(tlsuv_http_req_t *req, char *chunk, ssize_t status) {
     auto rc = static_cast<resp_capture *>(req->data);
     rc->req_body.append(chunk);
     rc->req_body_cb_called = true;
 }
 
-void resp_body_cb(tlsuv_http_req_t *req, const char *chunk, ssize_t len) {
+void resp_body_cb(tlsuv_http_req_t *req, char *chunk, ssize_t len) {
     auto rc = static_cast<resp_capture *>(req->data);
 
     if (len > 0) {
@@ -466,7 +468,7 @@ TEST_CASE("client_idle_test","[http]") {
 
     tlsuv_http_t clt;
 
-    tlsuv_http_body_cb bodyCb = [](tlsuv_http_req_t *req, const char *b, ssize_t len) {
+    tlsuv_http_body_cb bodyCb = [](tlsuv_http_req_t *req, char *b, ssize_t len) {
         auto r = static_cast<resp_capture *>(req->data);
 
         if (len == UV_EOF) {
@@ -503,7 +505,7 @@ TEST_CASE("server_idle_close","[.]") {
 
     tlsuv_http_t clt;
 
-    tlsuv_http_body_cb body_cb = [](tlsuv_http_req_t *req, const char *b, ssize_t len) {
+    tlsuv_http_body_cb body_cb = [](tlsuv_http_req_t *req, char *b, ssize_t len) {
         auto r = static_cast<resp_capture *>(req->data);
 
         if (len == UV_EOF) {
@@ -939,8 +941,12 @@ TEST_CASE("URL encode", "[http]") {
     CHECK_THAT(resp.http_version, Equals("1.1"));
     CHECK_THAT(resp.status, Equals("OK"));
     CHECK(resp.resp_body_end_called == 1);
-    CHECK_THAT(resp.body, Contains("this is a <test>!", Catch::CaseSensitive::No));
-    CHECK_THAT(resp.body, Contains(R"("url": "http://localhost/anything?query=this%20is%20a%20%3Ctest%3E!")", Catch::CaseSensitive::No));
+    auto json = json_value_get_object(json_parse_string(resp.body.c_str()));
+    auto query = json_array_get_string(json_object_dotget_array(json, "args.query"), 0);
+    auto url = json_object_dotget_string(json, "url");
+
+    CHECK_THAT(query, Equals("this is a <test>!"));
+    CHECK_THAT(url, Equals("http://localhost/anything?query=this%20is%20a%20%3Ctest%3E!"));
 
     std::cout << resp.req_body << std::endl;
 
@@ -960,6 +966,43 @@ public:
     resp_capture resp2;
 
 };
+
+TEST_CASE("form test", "[http]") {
+    std::string scheme = GENERATE("http", "https");
+    UvLoopTest test;
+
+    tlsuv_http_t clt;
+    resp_capture resp(resp_body_cb);
+
+    tlsuv_http_init(test.loop, &clt, testServerURL(scheme).c_str());
+    tlsuv_http_set_ssl(&clt, testServerTLS());
+    tlsuv_http_req_t *req = tlsuv_http_req(&clt, "POST", "/post", resp_capture_cb, &resp);
+
+    tlsuv_http_req_form(req, 3, (tlsuv_http_pair[]){
+            {"foo", "bar"},
+            {"message", "Check out https://openziti.io"},
+            {"end", "is near"}
+    });
+
+    test.run();
+
+    CHECK(resp.code == HTTP_STATUS_OK);
+    CHECK_THAT(resp.http_version, Equals("1.1"));
+    CHECK_THAT(resp.status, Equals("OK"));
+    CHECK(resp.resp_body_end_called == 1);
+    auto jval = json_parse_string(resp.body.c_str());
+    auto json = json_value_get_object(jval);
+    auto form = json_object_dotget_object(json, "form");
+    CHECK_THAT(json_array_get_string(json_object_dotget_array(form, "foo"), 0), Equals("bar"));
+    CHECK_THAT(json_array_get_string(json_object_dotget_array(form, "message"), 0), Equals("Check out https://openziti.io"));
+    CHECK_THAT(json_array_get_string(json_object_dotget_array(form, "end"), 0), Equals("is near"));
+
+    std::cout << resp.req_body << std::endl;
+
+    tlsuv_http_close(&clt, nullptr);
+
+    json_value_free(jval);
+}
 
 TEST_CASE("test request cancel", "[http]") {
     UvLoopTest test;

--- a/tests/http_tests.cpp
+++ b/tests/http_tests.cpp
@@ -978,11 +978,11 @@ TEST_CASE("form test", "[http]") {
     tlsuv_http_set_ssl(&clt, testServerTLS());
     tlsuv_http_req_t *req = tlsuv_http_req(&clt, "POST", "/post", resp_capture_cb, &resp);
 
-    tlsuv_http_req_form(req, 3, (tlsuv_http_pair[]){
-            {"foo", "bar"},
+    tlsuv_http_pair req_form[] = {
+            {"ziti", "is awesome!"},
             {"message", "Check out https://openziti.io"},
-            {"end", "is near"}
-    });
+    };
+    tlsuv_http_req_form(req, 2, req_form);
 
     test.run();
 

--- a/tests/http_tests.cpp
+++ b/tests/http_tests.cpp
@@ -993,9 +993,8 @@ TEST_CASE("form test", "[http]") {
     auto jval = json_parse_string(resp.body.c_str());
     auto json = json_value_get_object(jval);
     auto form = json_object_dotget_object(json, "form");
-    CHECK_THAT(json_array_get_string(json_object_dotget_array(form, "foo"), 0), Equals("bar"));
+    CHECK_THAT(json_array_get_string(json_object_dotget_array(form, "ziti"), 0), Equals("is awesome!"));
     CHECK_THAT(json_array_get_string(json_object_dotget_array(form, "message"), 0), Equals("Check out https://openziti.io"));
-    CHECK_THAT(json_array_get_string(json_object_dotget_array(form, "end"), 0), Equals("is near"));
 
     std::cout << resp.req_body << std::endl;
 

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -35,6 +35,10 @@
         {
           "name": "catch2",
           "version>=": "2.13.9#1"
+        },
+        {
+          "name": "parson",
+          "$comment": "test response parsing/validations"
         }
       ]
     },


### PR DESCRIPTION
add convenience method for sending HTTP form request

```
   tlsuv_http_req_t *req = tlsuv_http_req(&clt, "POST", "/post", resp_cb, &resp);

    tlsuv_http_req_form(req, 2, (tlsuv_http_pair[]){
            {"ziti", "is awesome!"},
            {"message", "Check out https://openziti.io"},
    });

```