### PR TITLE
Read start: check ssl engine data

### DIFF
--- a/sample/common.c
+++ b/sample/common.c
@@ -42,7 +42,7 @@ void resp_cb(tlsuv_http_resp_t *resp, void *data) {
     printf("\n");
 }
 
-void body_cb(tlsuv_http_req_t *req, const char *body, ssize_t len) {
+void body_cb(tlsuv_http_req_t *req, char *body, ssize_t len) {
     if (len == UV_EOF) {
         printf("\n\n====================\nRequest completed\n");
     }

--- a/sample/common.h
+++ b/sample/common.h
@@ -19,6 +19,6 @@
 #include <tlsuv/http.h>
 
 void resp_cb(tlsuv_http_resp_t *resp, void *data);
-void body_cb(tlsuv_http_req_t *req, const char *body, ssize_t len);
+void body_cb(tlsuv_http_req_t *req, char *body, ssize_t len);
 void logger(int level, const char *file, unsigned int line, const char *msg);
 #endif //UV_MBED_COMMON_H

--- a/src/mbedtls/engine.c
+++ b/src/mbedtls/engine.c
@@ -765,6 +765,10 @@ static int mbedtls_read(tlsuv_engine_t engine, char *out, size_t *out_bytes, siz
         if (rc < 0) {
             if (rc == MBEDTLS_ERR_SSL_WANT_READ || rc == MBEDTLS_ERR_SSL_WANT_WRITE) {
                 err = TLS_AGAIN;
+            } else if (rc == MBEDTLS_ERR_SSL_PEER_CLOSE_NOTIFY) {
+                UM_LOG(DEBG, "mbedTLS: peer close notify");
+                eng->error = rc;
+                err = TLS_EOF;
             } else {
                 UM_LOG(ERR, "mbedTLS: %0x(%s)", rc, mbedtls_error(rc));
                 eng->error = rc;

--- a/src/tlsuv.c
+++ b/src/tlsuv.c
@@ -119,6 +119,12 @@ static void on_internal_close(uv_handle_t *h) {
         req->cb(req, UV_ECANCELED);
     }
 
+    if (h->data) {
+        uv_idle_t *idle = h->data;
+        assert(idle->type == UV_IDLE);
+        uv_close((uv_handle_t *) idle, (uv_close_cb) free);
+    }
+
     // error handling
     // fail all pending requests
     fail_pending_reqs(clt, UV_ECANCELED);

--- a/src/util.h
+++ b/src/util.h
@@ -7,6 +7,10 @@
 
 #include <assert.h>
 
+
+#define container_of(ptr, type, member) \
+  ((type *) ((char *) (ptr) - offsetof(type, member)))
+
 /**
  * wrap-around buffer
  */

--- a/tests/stream_tests.cpp
+++ b/tests/stream_tests.cpp
@@ -153,10 +153,13 @@ TEST_CASE("read/write","[stream]") {
             auto ctx = (struct test_ctx *) c->data;
             if (status == UV_EOF) {
                 tlsuv_stream_close(c, nullptr);
+            } else if (status >= 0) {
+                if (status > 0) {
+                    REQUIRE_THAT(b->base, Catch::Matchers::StartsWith("HTTP/1.1 200 OK"));
+                    fprintf(stderr, "%.*s\n", (int) status, b->base);
+                }
             } else {
-                REQUIRE(status > 0);
-                REQUIRE_THAT(b->base, Catch::Matchers::StartsWith("HTTP/1.1 200 OK"));
-                fprintf(stderr, "%.*s\n", (int) status, b->base);
+                FAIL("status: " << status << " " << uv_strerror(status));
             }
             free(b->base);
         });


### PR DESCRIPTION
when application stops reading (`tlsuv_stream_read_stop`) or right after handshake is complete, there may be SSL data that was already read from the wire but not processed/delivered to application. 

This change makes sure that buffered SSL data is delivered to the application as soon as requested via `tlsuv_stream_read_start()`