### PR TITLE
Condition linux TCP keepalive sockopts

### DIFF
--- a/src/tlsuv.c
+++ b/src/tlsuv.c
@@ -169,8 +169,10 @@ int tlsuv_stream_keepalive(tlsuv_stream_t *clt, int keepalive, unsigned int dela
 #if defined(TCP_KEEPALIVE)
         setsockopt(s, IPPROTO_TCP, TCP_KEEPALIVE, &delay, sizeof(delay));
 #endif
+#if __linux__
         setsockopt(s, IPPROTO_TCP, TCP_KEEPINTVL, &intvl, sizeof(intvl));
         setsockopt(s, IPPROTO_TCP, TCP_KEEPCNT, &count, sizeof(count));
+#endif
     }
     return 0;
 }


### PR DESCRIPTION
It's specific for Linux, so condition it on __linux__.

This change was introduced rather recently and I presume no one attempted to compile it on anything that's not Linux. It would be great with cross-platform CI builds to catch things like this...