### PR TITLE
Add support for overriding tlsuv_socket behavior

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,6 +35,7 @@ set(tlsuv_sources
         src/tls_engine.c
         src/p11.c
         src/p11.h
+        src/socket.c
         src/util.h
         src/connector.c
         src/alloc.c

--- a/src/socket.c
+++ b/src/socket.c
@@ -1,0 +1,39 @@
+// Copyright (c) 2024. NetFoundry Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+//
+// You may obtain a copy of the License at
+// https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "util.h"
+#include <uv.h>
+
+uv_os_sock_t tlsuv_socket(const struct addrinfo *addr, bool blocking) {
+    uv_os_sock_t sock = socket(addr->ai_family, addr->ai_socktype, addr->ai_protocol);
+
+    int on = 1;
+    int flags;
+
+#if defined(SO_NOSIGPIPE)
+    setsockopt(sock, SOL_SOCKET, SO_NOSIGPIPE, &on, sizeof(on));
+#elif defined(F_SETNOSIGPIPE)
+    fcntl(sock, F_SETNOSIGPIPE, on);
+#endif
+
+#if defined(FD_CLOEXEC)
+    flags = fcntl(sock, F_GETFD);
+    fcntl(sock, F_SETFD, flags | FD_CLOEXEC);
+#endif
+
+    tlsuv_socket_set_blocking(sock, blocking);
+
+    return sock;
+}
+

--- a/src/tlsuv.c
+++ b/src/tlsuv.c
@@ -639,28 +639,6 @@ int tlsuv_stream_free(tlsuv_stream_t *clt) {
     return 0;
 }
 
-uv_os_sock_t tlsuv_socket(const struct addrinfo *addr, bool blocking) {
-    uv_os_sock_t sock = socket(addr->ai_family, addr->ai_socktype, addr->ai_protocol);
-
-    int on = 1;
-    int flags;
-
-#if defined(SO_NOSIGPIPE)
-    setsockopt(sock, SOL_SOCKET, SO_NOSIGPIPE, &on, sizeof(on));
-#elif defined(F_SETNOSIGPIPE)
-    fcntl(sock, F_SETNOSIGPIPE, on);
-#endif
-
-#if defined(FD_CLOEXEC)
-    flags = fcntl(sock, F_GETFD);
-    fcntl(sock, F_SETFD, flags | FD_CLOEXEC);
-#endif
-
-    tlsuv_socket_set_blocking(sock, blocking);
-
-    return sock;
-}
-
 int tlsuv_socket_set_blocking(uv_os_sock_t s, bool blocking) {
 
 #if defined(O_NONBLOCK)


### PR DESCRIPTION
This patch allows developers to override the `tlsuv_socket` definition, enabling customization of protocols (e.g., SCTP or multipath TCP) or socket options. By placing the function in a separate file, it adheres to the linking rules of static libraries without requiring the `weak` annotation.