### PR TITLE
load system CA on android from proper location

### DIFF
--- a/src/openssl/engine.c
+++ b/src/openssl/engine.c
@@ -16,6 +16,7 @@
 #error "USE_OPENSSL must be set to compile this file"
 #endif
 
+#include <assert.h>
 #include <stdbool.h>
 #include <stdlib.h>
 #include <string.h>
@@ -25,10 +26,10 @@
 #include "../um_debug.h"
 #include <tlsuv/tlsuv.h>
 
+#include <openssl/err.h>
 #include <openssl/x509.h>
 #include <openssl/ssl.h>
-#include <openssl/err.h>
-#include <assert.h>
+#include <openssl/types.h>
 
 #include "keys.h"
 #include "../keychain.h"

--- a/src/openssl/engine.c
+++ b/src/openssl/engine.c
@@ -36,8 +36,6 @@
 
 #if _WIN32
 #include <windows.h>
-#include <wincrypt.h>
-#pragma comment (lib, "crypt32.lib")
 #ifndef PATH_MAX
 #define PATH_MAX MAX_PATH
 #endif
@@ -1116,6 +1114,8 @@ goto on_error;            \
 }
 
 #if _WIN32
+#include <wincrypt.h>
+#pragma comment (lib, "crypt32.lib")
 
 static X509_STORE *load_system_certs() {
     X509_STORE *store = X509_STORE_new();

--- a/src/openssl/engine.c
+++ b/src/openssl/engine.c
@@ -33,6 +33,15 @@
 #include "keys.h"
 #include "../keychain.h"
 
+#if _WIN32
+#include <windows.h>
+#include <wincrypt.h>
+#pragma comment (lib, "crypt32.lib")
+#ifndef PATH_MAX
+#define PATH_MAX MAX_PATH
+#endif
+#endif
+
 
 // inspired by https://golang.org/src/crypto/x509/root_linux.go
 // Possible certificate files; stop after finding one.
@@ -1106,8 +1115,6 @@ goto on_error;            \
 }
 
 #if _WIN32
-#include <wincrypt.h>
-#pragma comment (lib, "crypt32.lib")
 
 static X509_STORE *load_system_certs() {
     X509_STORE *store = X509_STORE_new();


### PR DESCRIPTION
also fixes system CA lookup on Android to use the old hashing algorithm: see openssl/openssl#13565 
and openssl/openssl#24002