### PR TITLE
check client before failing requests

### DIFF
--- a/src/http.c
+++ b/src/http.c
@@ -145,6 +145,7 @@ static void fail_active_request(tlsuv_http_t *c, int code, const char *msg) {
 }
 
 static void fail_all_requests(tlsuv_http_t *c, int code, const char *msg) {
+    if (!c) return;
     // move the queue to avoid failing requests added
     // during error handing
     struct req_q queue = c->requests;


### PR DESCRIPTION
```
Thread 1 Crashed::  Dispatch queue: com.apple.root.default-qos
0   PacketTunnelProvider.debug.dylib	       0x103c0b9fc fail_all_requests + 28 (http.c:150)
1   PacketTunnelProvider.debug.dylib	       0x103c0cf4c tlsuv_http_cancel_all + 52 (http.c:629)
2   PacketTunnelProvider.debug.dylib	       0x103bcd068 ziti_ctrl_cancel + 28 (ziti_ctrl.c:686)
3   PacketTunnelProvider.debug.dylib	       0x103bc0de0 ziti_stop_internal + 620 (ziti.c:527)
4   PacketTunnelProvider.debug.dylib	       0x103bc6228 ztx_work_async + 208 (ziti.c:1777)
5   PacketTunnelProvider.debug.dylib	       0x103e9a7bc uv__async_io + 264
6   PacketTunnelProvider.debug.dylib	       0x103eaaee0 uv__io_poll + 948
7   PacketTunnelProvider.debug.dylib	       0x103e9acf8 uv_run + 416
```