### PR TITLE
openssl: avoid refcount errors

### DIFF
--- a/src/openssl/keys.c
+++ b/src/openssl/keys.c
@@ -148,7 +148,6 @@ static tlsuv_private_key_t new_private_key(EVP_PKEY *pkey) {
     struct priv_key_s *private_key = tlsuv__calloc(1, sizeof(struct priv_key_s));
     *private_key = PRIV_KEY_API;
     private_key->pkey = pkey;
-    private_key->ref_count = 1;
     return (tlsuv_private_key_t) private_key;
 }
 
@@ -232,11 +231,8 @@ static int pubkey_verify(tlsuv_public_key_t pk, enum hash_algo md, const char *d
 
 static void privkey_free(tlsuv_private_key_t k) {
     struct priv_key_s *priv = (struct priv_key_s *) k;
-    priv->ref_count--;
-    if (priv->ref_count < 1) {
-        EVP_PKEY_free(priv->pkey);
-        tlsuv__free(priv);
-    }
+    EVP_PKEY_free(priv->pkey);
+    tlsuv__free(priv);
 }
 
 static int privkey_sign(tlsuv_private_key_t pk, enum hash_algo md, const char *data, size_t datalen, char *sig, size_t *siglen) {

--- a/src/openssl/keys.c
+++ b/src/openssl/keys.c
@@ -29,6 +29,12 @@
 #include "../alloc.h"
 #include "../keychain.h"
 
+// OpenSSL 3.0.12+ defines this in openssl/evp.h
+#ifndef EVP_PKEY_PRIVATE_KEY
+# define EVP_PKEY_PRIVATE_KEY                                               \
+    ( EVP_PKEY_KEY_PARAMETERS | OSSL_KEYMGMT_SELECT_PRIVATE_KEY )
+#endif
+
 static int cert_to_pem(const struct tlsuv_certificate_s * c, int full, char **pem, size_t *pemlen);
 static void cert_free(tlsuv_certificate_t c);
 static int cert_verify(const struct tlsuv_certificate_s * c, enum hash_algo md, const char *data, size_t datalen, const char *sig, size_t siglen);

--- a/src/openssl/keys.h
+++ b/src/openssl/keys.h
@@ -31,7 +31,6 @@ struct pub_key_s {
 struct priv_key_s {
     TLSUV_PRIVKEY_API
     EVP_PKEY *pkey;
-    int ref_count;
 };
 
 const char *tls_error(unsigned long code);


### PR DESCRIPTION
no need to keep references to  own key/certs