### PR TITLE
Cert to string

### DIFF
--- a/include/tlsuv/tls_engine.h
+++ b/include/tlsuv/tls_engine.h
@@ -166,6 +166,7 @@ typedef struct tlsuv_certificate_s *tlsuv_certificate_t;
     void (*free)(struct tlsuv_certificate_s * cert);                                \
     int (*to_pem)(const struct tlsuv_certificate_s * cert, int full, char **pem, size_t *pemlen);   \
     int (*get_expiration)(const struct tlsuv_certificate_s * cert, struct tm *);          \
+    const char* (*get_text)(const struct tlsuv_certificate_s * cert);                     \
     int (*verify)(const struct tlsuv_certificate_s * cert, enum hash_algo md,             \
                   const char *data, size_t datalen, const char *sig, size_t siglen);
 

--- a/src/openssl/keys.c
+++ b/src/openssl/keys.c
@@ -35,6 +35,7 @@
     ( EVP_PKEY_KEY_PARAMETERS | OSSL_KEYMGMT_SELECT_PRIVATE_KEY )
 #endif
 
+static const char* cert_to_text(const struct tlsuv_certificate_s * cert);
 static int cert_to_pem(const struct tlsuv_certificate_s * c, int full, char **pem, size_t *pemlen);
 static void cert_free(tlsuv_certificate_t c);
 static int cert_verify(const struct tlsuv_certificate_s * c, enum hash_algo md, const char *data, size_t datalen, const char *sig, size_t siglen);
@@ -44,6 +45,7 @@ static struct cert_s cert_API = {
         .free = cert_free,
         .verify = cert_verify,
         .to_pem = cert_to_pem,
+        .get_text = cert_to_text,
         .get_expiration = cert_exp,
 };
 
@@ -853,12 +855,33 @@ static int privkey_store_cert(tlsuv_private_key_t pk, tlsuv_certificate_t cert) 
     return rc;
 }
 
+static const char* cert_to_text(const struct tlsuv_certificate_s * cert) {
+    struct cert_s *c = (struct cert_s *) cert;
+
+    if(c->text) return c->text;
+
+    STACK_OF(X509_OBJECT) *s = X509_STORE_get0_objects(c->cert);
+    X509 *x509 = X509_OBJECT_get0_X509(sk_X509_OBJECT_value(s, 0));
+
+    BIO *bio = BIO_new(BIO_s_mem());
+    X509_print_ex(bio, x509, 0, X509_FLAG_NO_HEADER | X509_FLAG_NO_SIGDUMP);
+
+    int len = BIO_pending(bio);
+    c->text = tlsuv__malloc(len + 1);
+    BIO_read(bio, c->text, len);
+    c->text[len] = '\0'; // ensure null-termination
+    BIO_free(bio);
+
+    return c->text;
+}
+
 static void cert_free(tlsuv_certificate_t cert) {
     struct cert_s *c = (struct cert_s *) cert;
     X509_STORE *s = c->cert;
     if (s != NULL) {
         X509_STORE_free(s);
     }
+    tlsuv__free(c->text);
     tlsuv__free(c);
 }
 

--- a/src/openssl/keys.c
+++ b/src/openssl/keys.c
@@ -864,7 +864,9 @@ static const char* cert_to_text(const struct tlsuv_certificate_s * cert) {
     X509 *x509 = X509_OBJECT_get0_X509(sk_X509_OBJECT_value(s, 0));
 
     BIO *bio = BIO_new(BIO_s_mem());
-    X509_print_ex(bio, x509, 0, X509_FLAG_NO_HEADER | X509_FLAG_NO_SIGDUMP);
+    X509_print_ex(bio, x509, 0,
+                  X509_FLAG_NO_HEADER | X509_FLAG_NO_SIGDUMP |
+                  X509_FLAG_NO_SIGNAME | X509_FLAG_EXTENSIONS_ONLY_KID);
 
     int len = BIO_pending(bio);
     c->text = tlsuv__malloc(len + 1);

--- a/src/openssl/keys.h
+++ b/src/openssl/keys.h
@@ -21,6 +21,7 @@
 struct cert_s {
     TLSUV_CERT_API
     X509_STORE *cert;
+    char *text;
 };
 
 struct pub_key_s {

--- a/src/win32crypto/cert.c
+++ b/src/win32crypto/cert.c
@@ -177,10 +177,159 @@ static int get_expiration(const struct tlsuv_certificate_s *cert,  struct tm *tm
     return 0;
 }
 
+static void fmt_time(const FILETIME *ft, char *out, size_t len) {
+    SYSTEMTIME st;
+    FileTimeToSystemTime(ft, &st);
+    struct tm t = {
+            .tm_sec = st.wSecond,
+            .tm_min = st.wMinute,
+            .tm_hour = st.wHour,
+            .tm_mday = st.wDay,
+            .tm_mon = st.wMonth - 1,
+            .tm_year = st.wYear - 1900
+    };
+
+    // Jul 31 17:25:35 2024 GMT
+    strftime(out, len, "%b %d %H:%M:%S %Y GMT", &t);
+}
+
+static char EC_PUB_FMT[] = "Public Key Algorithm: id-ecPublicKey\n"
+                           "Public-Key: (%d bit)\n"
+                           "ASN1 OID: %s\n";
+
+static void fmt_pub_key_info(CERT_PUBLIC_KEY_INFO *keyInfo, char *buf, size_t len) {
+    if (strcmp(keyInfo->Algorithm.pszObjId, szOID_ECC_PUBLIC_KEY) == 0) {
+
+        int key_size = 0;
+        LPSTR *oid = NULL;
+        const char *alg_id = NULL;
+        DWORD l = 0;
+        CryptDecodeObjectEx(X509_ASN_ENCODING, X509_OBJECT_IDENTIFIER,
+                            keyInfo->Algorithm.Parameters.pbData, keyInfo->Algorithm.Parameters.cbData,
+                            CRYPT_DECODE_ALLOC_FLAG, 0,
+                            &oid, &l
+        );
+        if (strcmp(*oid, szOID_ECC_CURVE_P256) == 0) {
+            key_size = 256;
+            alg_id = "prime256v1";
+        } else if (strcmp(*oid, szOID_ECC_CURVE_P384) == 0) {
+            key_size = 384;
+            alg_id = "secp384r1";
+        } else if (strcmp(*oid, szOID_ECC_CURVE_P521) == 0) {
+            key_size = 521;
+            alg_id = "secp521r1";
+        } else {
+            key_size = -1;
+            alg_id = *oid;
+        }
+        snprintf(buf, len, EC_PUB_FMT, key_size, alg_id);
+        LocalFree(oid);
+        return;
+    } else if(strcmp(keyInfo->Algorithm.pszObjId, szOID_RSA_RSA) == 0) {
+        unsigned long bits = keyInfo->PublicKey.cbData * 8 - keyInfo->PublicKey.cUnusedBits;
+        static char RSA_PUB_FMT[] = "Public Key Algorithm: rsaEncryption\n"
+                                    "Public-Key: (%ld bit)\n";
+        snprintf(buf, len, RSA_PUB_FMT, bits);
+    } else {
+        snprintf(buf, len, "<unsupported>\n");
+    }
+}
+
+const char * get_text(const struct tlsuv_certificate_s * cert) {
+    win32_cert_t *c = (win32_cert_t *) cert;
+    
+    if (c->text) return c->text;
+
+    PCCERT_CONTEXT cert_ctx = c->cert;
+    if (!cert_ctx) {
+        UM_LOG(ERR, "No certificates found in store");
+        return NULL;
+    }
+    
+
+    // produce output similar OpenSSL/X509_print_ex, skipping more technical bits
+    static char CERT_TEXT_FMT[] = "Version: %lu (0x%lx)\n"
+                                  "Serial Number: %ld (0x%lX)\n"
+                                  "Issuer: %s\n"
+                                  "Validity\n"
+                                  "Not Before: %s\n"
+                                  "Not After : %s\n"
+                                  "Subject: %s\n"
+                                  "Subject Public Key Info:\n"
+                                  "%s"
+                                  "X509v3 extensions:\n"
+                                  "X509v3 Authority Key Identifier:\n"
+                                  "%s";
+
+    unsigned long serial = 0;
+    for (int i = 0; i < cert_ctx->pCertInfo->SerialNumber.cbData; i++) {
+        serial += cert_ctx->pCertInfo->SerialNumber.pbData[i] << (8 * i);
+    }
+
+    char issuer[256] = {};
+    char subject[256] = {};
+    CertNameToStrA(X509_ASN_ENCODING, &cert_ctx->pCertInfo->Issuer, CERT_X500_NAME_STR, issuer, sizeof(issuer));
+    CertNameToStrA(X509_ASN_ENCODING, &cert_ctx->pCertInfo->Subject, CERT_X500_NAME_STR, subject, sizeof(subject));
+
+    struct tm aft;
+    SYSTEMTIME before = {}, after = {};
+    FileTimeToSystemTime(&cert_ctx->pCertInfo->NotBefore, &before);
+    FileTimeToSystemTime(&cert_ctx->pCertInfo->NotAfter, &after);
+    char not_before[64];
+    char not_after[64];
+    fmt_time(&cert_ctx->pCertInfo->NotBefore, not_before, sizeof(not_before));
+    fmt_time(&cert_ctx->pCertInfo->NotAfter, not_after, sizeof(not_after));
+
+    char key_info[256];
+    fmt_pub_key_info(&cert_ctx->pCertInfo->SubjectPublicKeyInfo, key_info, sizeof(key_info));
+
+    char key_id[128] = "<unknown>";
+    for (int i = 0; i < cert_ctx->pCertInfo->cExtension; i++) {
+        PCERT_EXTENSION ext = &cert_ctx->pCertInfo->rgExtension[i];
+        if (strcmp(ext->pszObjId, szOID_AUTHORITY_KEY_IDENTIFIER2) == 0) {
+            CERT_AUTHORITY_KEY_ID2_INFO *kid_info = NULL;
+            DWORD kid_info_len = 0;
+            if (CryptDecodeObject(X509_ASN_ENCODING, szOID_AUTHORITY_KEY_IDENTIFIER2, ext->Value.pbData, ext->Value.cbData, CRYPT_DECODE_ALLOC_FLAG, &kid_info, &kid_info_len)) {
+                BYTE *b = kid_info->KeyId.pbData;
+                char *p = key_id;
+                while (b - kid_info->KeyId.pbData < kid_info->KeyId.cbData) {
+                    p += snprintf(p, 4, "%02X:", *b++);
+                }
+                *(p - 1) = (char)0;
+                LocalFree(kid_info);
+            }
+        }
+    }
+    
+    ssize_t len = snprintf(NULL, 0, CERT_TEXT_FMT,
+                          cert_ctx->pCertInfo->dwVersion, cert_ctx->pCertInfo->dwVersion,
+                          serial, serial,
+                          issuer, // issuer
+                          not_before,
+                          not_after,
+                          subject,
+                          key_info,
+                          key_id);
+
+    c->text = tlsuv__malloc(len + 1);
+    snprintf(c->text, len + 1, CERT_TEXT_FMT,
+             cert_ctx->pCertInfo->dwVersion + 1, cert_ctx->pCertInfo->dwVersion,
+             serial, serial,
+             issuer, // issuer
+             not_before,
+             not_after,
+             subject,
+             key_info,
+             key_id
+    );
+    return c->text;
+}
+
 static struct tlsuv_certificate_s cert_api = {
     .free = free_cert,
     .to_pem = cert_to_pem,
     .get_expiration = get_expiration,
+    .get_text = get_text,
     .verify = cert_verify,
 };
 

--- a/src/win32crypto/cert.h
+++ b/src/win32crypto/cert.h
@@ -25,6 +25,7 @@ typedef struct win32_cert {
     struct tlsuv_certificate_s api;
     HCERTSTORE store;
     PCCERT_CONTEXT cert;
+    char *text;
 } win32_cert_t;
 
 extern win32_cert_t *win32_new_cert(PCCERT_CONTEXT, HCERTSTORE);

--- a/tests/key_tests.cpp
+++ b/tests/key_tests.cpp
@@ -556,9 +556,47 @@ ClE70UxGSsMjY8Evg0qSemyX/S63aziH1I9+m+3BUF+bg75zTmirgzIPt3B0mbD4Rx99DC6bE9n8
 Z8AgrJehwuXYVyJrG5Tc1vnlSUhUrK2812JyXA7tkWj/qzc=
 -----END CERTIFICATE-----
 )";
+    const char *cert_text = R"(        Version: 3 (0x2)
+        Serial Number: 309216 (0x4b7e0)
+        Signature Algorithm: sha256WithRSAEncryption
+        Issuer: C=US, ST=NC, L=Charlotte, O=NetFoundry, CN=Ziti Controller Intermediate CA/emailAddress=support@netfoundry.io
+        Validity
+            Not Before: Jul 31 17:25:35 2024 GMT
+            Not After : Jul 31 17:26:35 2025 GMT
+        Subject: CN=CafSvpHp0
+        Subject Public Key Info:
+            Public Key Algorithm: id-ecPublicKey
+                Public-Key: (256 bit)
+                pub:
+                    04:f7:65:65:32:b2:6f:f5:87:70:df:76:93:09:e7:
+                    c9:b7:03:07:80:32:af:98:3a:89:26:41:f8:49:3c:
+                    cc:ff:ee:54:24:32:ed:48:5e:73:ed:37:ed:54:56:
+                    76:ad:9b:cb:68:33:c3:d6:bb:38:26:95:9d:8a:c7:
+                    00:49:87:64:f7
+                ASN1 OID: prime256v1
+                NIST CURVE: P-256
+        X509v3 extensions:
+            X509v3 Key Usage: critical
+                Digital Signature, Key Encipherment, Data Encipherment
+            X509v3 Extended Key Usage:
+                TLS Web Client Authentication
+            X509v3 Authority Key Identifier:
+                6B:7D:E4:C8:04:D6:E1:10:34:9A:03:95:47:9B:C9:32:7F:EF:F5:09
+)";
     auto tls = default_tls_context(nullptr, 0);
     tlsuv_certificate_t cert = nullptr;
     CHECK(tls->load_cert(&cert, pem, strlen(pem)) == 0);
+
+    if (cert->get_text) {
+        const char *text = cert->get_text(cert);
+        size_t textlen = 0;
+        CHECK(text != nullptr);
+        CHECK_THAT(text, Catch::Matchers::ContainsSubstring("Subject: CN=CafSvpHp0"));
+        CHECK_THAT(text, Catch::Matchers::ContainsSubstring(
+                "Issuer: C=US, ST=NC, L=Charlotte, O=NetFoundry, CN=Ziti Controller Intermediate CA/emailAddress=support@netfoundry.io"));
+        printf("Cert text:\n%s\n", text);
+    }
+
     cert->free(cert);
     tls->free_ctx(tls);
 }

--- a/tests/key_tests.cpp
+++ b/tests/key_tests.cpp
@@ -556,44 +556,15 @@ ClE70UxGSsMjY8Evg0qSemyX/S63aziH1I9+m+3BUF+bg75zTmirgzIPt3B0mbD4Rx99DC6bE9n8
 Z8AgrJehwuXYVyJrG5Tc1vnlSUhUrK2812JyXA7tkWj/qzc=
 -----END CERTIFICATE-----
 )";
-    const char *cert_text = R"(        Version: 3 (0x2)
-        Serial Number: 309216 (0x4b7e0)
-        Signature Algorithm: sha256WithRSAEncryption
-        Issuer: C=US, ST=NC, L=Charlotte, O=NetFoundry, CN=Ziti Controller Intermediate CA/emailAddress=support@netfoundry.io
-        Validity
-            Not Before: Jul 31 17:25:35 2024 GMT
-            Not After : Jul 31 17:26:35 2025 GMT
-        Subject: CN=CafSvpHp0
-        Subject Public Key Info:
-            Public Key Algorithm: id-ecPublicKey
-                Public-Key: (256 bit)
-                pub:
-                    04:f7:65:65:32:b2:6f:f5:87:70:df:76:93:09:e7:
-                    c9:b7:03:07:80:32:af:98:3a:89:26:41:f8:49:3c:
-                    cc:ff:ee:54:24:32:ed:48:5e:73:ed:37:ed:54:56:
-                    76:ad:9b:cb:68:33:c3:d6:bb:38:26:95:9d:8a:c7:
-                    00:49:87:64:f7
-                ASN1 OID: prime256v1
-                NIST CURVE: P-256
-        X509v3 extensions:
-            X509v3 Key Usage: critical
-                Digital Signature, Key Encipherment, Data Encipherment
-            X509v3 Extended Key Usage:
-                TLS Web Client Authentication
-            X509v3 Authority Key Identifier:
-                6B:7D:E4:C8:04:D6:E1:10:34:9A:03:95:47:9B:C9:32:7F:EF:F5:09
-)";
     auto tls = default_tls_context(nullptr, 0);
     tlsuv_certificate_t cert = nullptr;
     CHECK(tls->load_cert(&cert, pem, strlen(pem)) == 0);
 
     if (cert->get_text) {
         const char *text = cert->get_text(cert);
-        size_t textlen = 0;
         CHECK(text != nullptr);
         CHECK_THAT(text, Catch::Matchers::ContainsSubstring("Subject: CN=CafSvpHp0"));
-        CHECK_THAT(text, Catch::Matchers::ContainsSubstring(
-                "Issuer: C=US, ST=NC, L=Charlotte, O=NetFoundry, CN=Ziti Controller Intermediate CA/emailAddress=support@netfoundry.io"));
+        CHECK_THAT(text, Catch::Matchers::ContainsSubstring("ASN1 OID: prime256v1"));
         printf("Cert text:\n%s\n", text);
     }
 


### PR DESCRIPTION
adds `tlsuv_certificate_t.get_text()` to return human readable text (similar to `openssl x509 -text`)