### PR TITLE
avoid calling null tr_close

### DIFF
--- a/src/http.c
+++ b/src/http.c
@@ -299,8 +299,6 @@ static void on_tls_connect(uv_connect_t *req, int status) {
 
     CLT_LOG(VERB, "TLS handshake completed");
     c->tr = (uv_handle_t*)s;
-    c->tr_close = (void (*)(uv_handle_t *, uv_close_cb)) tlsuv_stream_close;
-    c->tr_write = tls_write_shim;
     tlsuv_stream_read_start(s, tr_alloc_cb, tr_read_cb);
     c->connected = Connected;
     safe_continue(c);
@@ -317,6 +315,9 @@ static void tr_connect_cb(uv_os_sock_t sock, int status, void *ctx) {
         tlsuv_stream_init(c->proc.loop, s, c->tls ? c->tls : get_default_tls());
         s->data = c;
         c->tr = (uv_handle_t*)s;
+        // set close callback now incase it is needed when the connection fails
+        c->tr_close = (void (*)(uv_handle_t *, uv_close_cb)) tlsuv_stream_close;
+        c->tr_write = tls_write_shim;
         tlsuv_stream_set_hostname(s, c->host);
 
         uv_connect_t *cr = tlsuv__calloc(1, sizeof(*cr));


### PR DESCRIPTION
https://github.com/openziti/ziti-sdk-c/pull/937 makes it possible to once again toggle identity enabled/disabled. doing so rapidly would lead to crashes with tlsuv 0.39.5

<img width="1624" height="1056" alt="Screenshot 2025-10-22 at 4 50 44 PM" src="https://github.com/user-attachments/assets/2540f3a2-eba2-4275-be87-27a8c67257bb" />
<img width="1624" height="1056" alt="Screenshot 2025-10-22 at 4 28 07 PM" src="https://github.com/user-attachments/assets/6eb3777e-74c5-43fa-ae70-3e3239e7f08f" />
