### PR TITLE
Add authmode support for TLS streams

### DIFF
--- a/include/tlsuv/tls_engine.h
+++ b/include/tlsuv/tls_engine.h
@@ -99,6 +99,13 @@ struct tlsuv_engine_s {
      */
     void (*set_protocols)(tlsuv_engine_t self, const char **protocols, int len);
 
+    /**
+     * set TLS engine authmode
+     * @param self engine
+     * @param authmode TLSUV_VERIFY_NONE or TLSUV_VERIFY_REQUIRED
+     */
+    void (*set_authmode)(tlsuv_engine_t self, int authmode);
+
     tls_handshake_state (*handshake_state)(tlsuv_engine_t self);
 
     /**

--- a/include/tlsuv/tlsuv.h
+++ b/include/tlsuv/tlsuv.h
@@ -165,6 +165,7 @@ struct tlsuv_stream_s {
     tls_context *tls;
     tlsuv_engine_t tls_engine;
 
+    int authmode;
     int alpn_count;
     const char **alpn_protocols;
 

--- a/src/mbedtls/engine.c
+++ b/src/mbedtls/engine.c
@@ -106,6 +106,7 @@ struct mbedtls_engine {
 };
 
 static void mbedtls_set_alpn_protocols(tlsuv_engine_t engine, const char** protos, int len);
+static void mbedtls_set_authmode(tlsuv_engine_t engine, int authmode);
 static int mbedtls_set_own_cert(tls_context *ctx, tlsuv_private_key_t key, tlsuv_certificate_t cert);
 
 tlsuv_engine_t new_mbedtls_engine(tls_context *ctx, const char *host);
@@ -185,6 +186,7 @@ static struct tlsuv_engine_s mbedtls_engine_api = {
         .set_io = mbedtls_set_io,
         .set_io_fd = mbedtls_set_fd,
         .set_protocols = mbedtls_set_alpn_protocols,
+        .set_authmode = mbedtls_set_authmode,
         .handshake_state = mbedtls_hs_state,
         .handshake = mbedtls_continue_hs,
         .get_alpn = mbedtls_get_alpn,
@@ -707,6 +709,11 @@ static void mbedtls_set_fd(tlsuv_engine_t e, uv_os_fd_t fd) {
     eng->io_fd = fd;
     eng->io = &eng->io_fd;
     mbedtls_ssl_set_bio(eng->ssl, eng->io, mbedtls_net_send, mbedtls_net_recv, NULL);
+}
+
+static void mbedtls_set_authmode(tlsuv_engine_t engine, int authmode) {
+    struct mbedtls_engine *eng = (struct mbedtls_engine *) engine;
+    mbedtls_ssl_conf_authmode(&eng->config, authmode);
 }
 
 static tls_handshake_state mbedtls_hs_state(tlsuv_engine_t engine) {

--- a/src/openssl/engine.c
+++ b/src/openssl/engine.c
@@ -77,6 +77,7 @@ tlsuv_engine_t new_openssl_engine(tls_context *ctx, const char *host);
 static void set_io(tlsuv_engine_t , io_ctx , io_read , io_write);
 static void set_io_fd(tlsuv_engine_t , tlsuv_sock_t);
 static void set_protocols(tlsuv_engine_t self, const char** protocols, int len);
+static void set_authmode(tlsuv_engine_t self, int authmode);
 
 static tls_handshake_state tls_hs_state(tlsuv_engine_t engine);
 static tls_handshake_state
@@ -149,6 +150,7 @@ static struct tlsuv_engine_s openssl_engine_api = {
         .set_io = set_io,
         .set_io_fd = set_io_fd,
         .set_protocols = set_protocols,
+        .set_authmode = set_authmode,
         .handshake_state = tls_hs_state,
         .handshake = tls_continue_hs,
         .get_alpn = tls_get_alpn,
@@ -683,6 +685,12 @@ static void set_protocols(tlsuv_engine_t self, const char** protocols, int len) 
     tlsuv__free(alpn_protocols);
 }
 
+static void set_authmode(tlsuv_engine_t self, int authmode) {
+    struct openssl_engine *e = (struct openssl_engine *)self;
+    int mode = authmode == 0 ? SSL_VERIFY_NONE : SSL_VERIFY_PEER;
+    SSL_set_verify(e->ssl, mode, NULL);
+}
+
 static int cert_verify_cb(X509_STORE_CTX *certs, void *ctx) {
     struct openssl_ctx *c = ctx;
 
@@ -1214,4 +1222,3 @@ BIO_METHOD *BIO_s_engine(void)
     }
     return engine_bio_meth;
 }
-


### PR DESCRIPTION
This adds an authmode field to tlsuv_stream_s and a set_authmode hook to the engine vtable. The stream init defaults to “verify required”, and the value is applied to OpenSSL (SSL_set_verify) and mbedTLS (mbedtls_ssl_conf_authmode) before handshake. This lets consumers disable certificate verification for local testing while keeping the default secure behavior.