### PR TITLE
implement HTTP request timeout

### DIFF
--- a/include/tlsuv/http.h
+++ b/include/tlsuv/http.h
@@ -117,6 +117,7 @@ struct tlsuv_http_req_s {
     llhttp_t parser;
     enum http_request_state state;
     bool keepalive;
+    long timeout;
 
     bool req_chunked;
     ssize_t req_body_size;
@@ -167,6 +168,7 @@ struct tlsuv_http_s {
 
     long connect_timeout;
     long idle_time;
+    long request_timeout;
     uv_timer_t *conn_timer;
 
     uv_idle_t proc;
@@ -260,6 +262,25 @@ int tlsuv_http_idle_keepalive(tlsuv_http_t *clt, long millis);
 int tlsuv_http_connect_timeout(tlsuv_http_t *clt, long millis);
 
 /**
+ * \brief Set request timeout.
+ *
+ * Sets the length of time client will wait for a request to complete.
+ * The timeout only applies to the currently active request: it starts when the request
+ * becomes active (is sent out on an established connection) and runs until the response
+ * is fully received. Requests waiting in the queue are not charged for that time.
+ * Establishing the connection is governed separately by tlsuv_http_connect_timeout().
+ * A request that times out is failed with `UV_ETIMEDOUT`.
+ *
+ * Only requests created after this call are affected.
+ * @see tlsuv_http_req_timeout
+ * @param clt
+ * @param millis timeout in milliseconds, use 0 to disable, default is 0.
+ *        Any value <= 0 disables the timeout.
+ * @return 0 or error code
+ */
+int tlsuv_http_request_timeout(tlsuv_http_t* clt, long millis);
+
+/**
  * @brief Set #tls_context on the client.
  *
  * Useful if you have custom TLS context (different implementation)
@@ -323,6 +344,17 @@ tlsuv_http_req_t *tlsuv_http_req(tlsuv_http_t *clt, const char *method, const ch
  * @return o or error code
  */
 int tlsuv_http_req_header(tlsuv_http_req_t *req, const char *name, const char *value);
+
+/**
+ * Set timeout for this request, overriding the value inherited from the client.
+ *
+ * @see tlsuv_http_request_timeout
+ * @param req
+ * @param millis timeout in milliseconds, use 0 to disable.
+ *        Any value <= 0 disables the timeout.
+ * @return 0 or error code
+ */
+int tlsuv_http_req_timeout(tlsuv_http_req_t* req, long millis);
 
 /**
  * Write request body. Could be called multiple times.

--- a/src/http.c
+++ b/src/http.c
@@ -78,6 +78,28 @@ enum status {
     Connected
 };
 
+static void request_timeout(uv_timer_t* t) {
+    tlsuv_http_t* c = t->data;
+    if (c->active == NULL) return;
+
+    CLT_LOG(WARN, "request[%s] timed out", c->active->path);
+    http_req_cancel_err(c, c->active, UV_ETIMEDOUT, uv_strerror(UV_ETIMEDOUT));
+}
+
+static void start_req_timer(tlsuv_http_t* c) {
+    if (c->conn_timer && c->active && c->active->timeout > 0) {
+        CLT_LOG(VERB, "starting request[%s] timeout[%ld]", c->active->path, c->active->timeout);
+        uv_timer_start(c->conn_timer, request_timeout, c->active->timeout, 0);
+    }
+}
+
+// conn_timer is shared, only stop it if it is being used for the request timeout
+static void stop_req_timer(tlsuv_http_t* c) {
+    if (c->conn_timer && c->conn_timer->timer_cb == request_timeout) {
+        uv_timer_stop(c->conn_timer);
+    }
+}
+
 static const uv_link_methods_t http_methods = {
         .close = uv_link_default_close,
         .read_start = uv_link_default_read_start,
@@ -143,12 +165,14 @@ static void clt_read_cb(tlsuv_http_t *c, ssize_t nread, const uv_buf_t *buf) {
             keepalive = false;
         } else if (ar->state == completed) {
             keepalive = c->keepalive && ar->keepalive;
+            stop_req_timer(c);
             c->active = NULL;
             http_req_free(ar);
             tlsuv__free(ar);
         }
     } else if (nread == UV_EOF) {
         if (http_req_finish(ar) == 0 && ar->state == completed) {
+            stop_req_timer(c);
             c->active = NULL;
             http_req_free(ar);
             tlsuv__free(ar);
@@ -191,6 +215,7 @@ static void fail_active_request(tlsuv_http_t *c, int code, const char *msg) {
     tlsuv_http_req_t *req = c->active;
 
     if (req == NULL || req->state == completed) return;
+    stop_req_timer(c);
     c->active = NULL;
 
     if (req->resp_cb != NULL) {
@@ -677,6 +702,7 @@ static void process_requests(uv_idle_t *ar) {
         CLT_LOG(VERB, "client connected, processing request[%s] state[%d]", c->active->path, c->active->state);
         if (c->active->state < headers_sent) {
             CLT_LOG(VERB, "sending request[%s] headers", c->active->path);
+            start_req_timer(c);
             uv_buf_t req;
             req.base = tlsuv__malloc(8196);
             ssize_t header_len = http_req_write(c->active, req.base, 8196);
@@ -837,6 +863,7 @@ int tlsuv_http_init_with_src(uv_loop_t *l, tlsuv_http_t *clt, const char *url, t
 
     clt->keepalive = true;
     clt->connect_timeout = 0;
+    clt->request_timeout = 0;
     clt->idle_time = DEFAULT_IDLE_TIMEOUT;
     clt->conn_timer = tlsuv__calloc(1, sizeof(uv_timer_t));
     uv_timer_init(l, clt->conn_timer);
@@ -869,6 +896,26 @@ int tlsuv_http_connect_timeout(tlsuv_http_t *clt, long millis) {
     return 0;
 }
 
+int tlsuv_http_request_timeout(tlsuv_http_t* clt, long millis) {
+    clt->request_timeout = millis;
+    return 0;
+}
+
+int tlsuv_http_req_timeout(tlsuv_http_req_t* req, long millis) {
+    req->timeout = millis;
+
+    // only re-arm if the shared timer is already running the request timeout for this request.
+    // while connecting the timer belongs to the connect timeout, and the request timer is armed
+    // with the new value when the request is sent out
+    tlsuv_http_t* clt = req->client;
+    if (clt && clt->active == req && clt->conn_timer &&
+        clt->conn_timer->timer_cb == request_timeout) {
+        stop_req_timer(clt);
+        start_req_timer(clt);
+    }
+    return 0;
+}
+
 int tlsuv_http_idle_keepalive(tlsuv_http_t *clt, long millis) {
     clt->keepalive = true;
     clt->idle_time = millis;
@@ -893,6 +940,7 @@ tlsuv_http_req_t *tlsuv_http_req(tlsuv_http_t *clt, const char *method, const ch
     http_req_init(r, method, path);
 
     r->client = clt;
+    r->timeout = clt->request_timeout;
     r->resp_cb = resp_cb;
     r->data = ctx;
 
@@ -931,6 +979,7 @@ int http_req_cancel_err(tlsuv_http_t *clt, tlsuv_http_req_t *req, int error, con
 
     if (r == req || req == clt->active) { // req is in the queue
         if (req == clt->active) {
+            stop_req_timer(clt);
             clt->active = NULL;
             // since active request is being canceled we don't want to consume what's left on the wire for it
             // and need to close connection

--- a/tests/http_tests.cpp
+++ b/tests/http_tests.cpp
@@ -894,6 +894,155 @@ TEST_CASE("TLS to IP address", "[http]") {
     test.run();
 }
 
+TEST_CASE("request timeout", "[http]") {
+    UvLoopTest test;
+
+    tlsuv_http_t clt;
+    resp_capture resp(resp_body_cb);
+
+    tlsuv_http_init(test.loop, &clt, testServerURL("http").c_str());
+    tlsuv_http_request_timeout(&clt, 1000);
+    tlsuv_http_req(&clt, "GET", "/delay/5", resp_capture_cb, &resp);
+
+    uv_timeval64_t start;
+    uv_gettimeofday(&start);
+    test.run();
+    uv_timeval64_t stop;
+    uv_gettimeofday(&stop);
+
+    THEN("request should time out well before the server responds") {
+        CHECK(resp.code == UV_ETIMEDOUT);
+        CHECK(duration(start, stop) < 3 * ONE_SECOND);
+    }
+
+    tlsuv_http_close(&clt, nullptr);
+    test.run();
+}
+
+TEST_CASE("per request timeout", "[http]") {
+    UvLoopTest test;
+
+    tlsuv_http_t clt;
+    resp_capture resp(resp_body_cb);
+    resp_capture resp2(resp_body_cb);
+
+    tlsuv_http_init(test.loop, &clt, testServerURL("http").c_str());
+    // no client-wide timeout
+    tlsuv_http_req_t* req = tlsuv_http_req(&clt, "GET", "/delay/5", resp_capture_cb, &resp);
+    tlsuv_http_req_timeout(req, 1000);
+
+    tlsuv_http_req(&clt, "GET", "/json", resp_capture_cb, &resp2);
+
+    test.run();
+
+    THEN("only the request with the timeout should fail") {
+        CHECK(resp.code == UV_ETIMEDOUT);
+        CHECK(resp2.code == HTTP_STATUS_OK);
+    }
+
+    tlsuv_http_close(&clt, nullptr);
+    test.run();
+}
+
+TEST_CASE("request timeout applies only to active request", "[http]") {
+    UvLoopTest test;
+
+    tlsuv_http_t clt;
+    resp_capture resp[3] = {
+        resp_capture(resp_body_cb), resp_capture(resp_body_cb), resp_capture(resp_body_cb)
+    };
+
+    tlsuv_http_init(test.loop, &clt, testServerURL("http").c_str());
+    tlsuv_http_request_timeout(&clt, 1500);
+
+    // each request takes ~1 second, the last one does not become active until ~2 seconds in
+    for (auto& r : resp) {
+        tlsuv_http_req(&clt, "GET", "/delay/1", resp_capture_cb, &r);
+    }
+
+    uv_timeval64_t start;
+    uv_gettimeofday(&start);
+    test.run();
+    uv_timeval64_t stop;
+    uv_gettimeofday(&stop);
+
+    THEN("queued requests are not charged for time spent waiting") {
+        for (auto& r : resp) {
+            CHECK(r.code == HTTP_STATUS_OK);
+        }
+        CHECK(duration(start, stop) > 2 * ONE_SECOND);
+    }
+
+    tlsuv_http_close(&clt, nullptr);
+    test.run();
+}
+
+TEST_CASE("request timeout during response body", "[http]") {
+    UvLoopTest test;
+
+    tlsuv_http_t clt;
+    tlsuv_http_body_cb bodyCb = [](tlsuv_http_req_t* req, char* b, ssize_t len) {
+        auto r = static_cast<resp_capture*>(req->data);
+        if (len > 0) {
+            r->body.append(b, len);
+        } else {
+            r->resp_body_end_called += 1;
+            r->code = len; // terminal code: UV_EOF or an error
+        }
+    };
+    resp_capture resp(bodyCb);
+
+    tlsuv_http_init(test.loop, &clt, testServerURL("http").c_str());
+    tlsuv_http_request_timeout(&clt, 1000);
+    // headers come back immediately, body is dribbled out over 5 seconds
+    tlsuv_http_req(&clt, "GET", "/drip?duration=5&delay=0&numbytes=100", resp_capture_cb, &resp);
+
+    test.run();
+
+    THEN("timeout is reported via body callback") {
+        CHECK(resp.headers["Content-Length"] == "100"); // headers were received
+        CHECK(resp.resp_body_end_called == 1);
+        CHECK(resp.code == UV_ETIMEDOUT);
+        CHECK(resp.body.size() < 100);
+    }
+
+    tlsuv_http_close(&clt, nullptr);
+    test.run();
+}
+
+TEST_CASE("request timeout does not disturb idle timeout", "[http]") {
+    UvLoopTest test;
+
+    tlsuv_http_t clt;
+    tlsuv_http_body_cb bodyCb = [](tlsuv_http_req_t* req, char* b, ssize_t len) {
+        auto r = static_cast<resp_capture*>(req->data);
+        if (len == UV_EOF) {
+            uv_gettimeofday(&r->resp_endtime);
+        }
+    };
+    resp_capture resp(bodyCb);
+
+    tlsuv_http_init(test.loop, &clt, testServerURL("http").c_str());
+    tlsuv_http_request_timeout(&clt, 5000);
+    tlsuv_http_idle_keepalive(&clt, 3000);
+    tlsuv_http_req(&clt, "GET", "/get", resp_capture_cb, &resp);
+
+    uv_timeval64_t start;
+    uv_gettimeofday(&start);
+    test.run();
+    uv_timeval64_t stop;
+    uv_gettimeofday(&stop);
+
+    THEN("request completes and connection is kept idle for the full idle time") {
+        CHECK(resp.code == HTTP_STATUS_OK);
+        CHECK(duration(start, resp.resp_endtime) < 2 * ONE_SECOND);
+        CHECK(duration(resp.resp_endtime, stop) >= (3 * ONE_SECOND - ONE_MILLI));
+    }
+
+    tlsuv_http_close(&clt, nullptr);
+    test.run();
+}
+
 TEST_CASE("connect timeout", "[http]") {
     UvLoopTest test;
 


### PR DESCRIPTION
Added support for configuring request timeouts in the HTTP client, configurable both globally per client and as an override per individual request.

 #### 1. API Additions (http.h)

  • tlsuv_http_request_timeout(tlsuv_http_t *clt, long millis): Sets a client-wide default request timeout (in milliseconds) inherited by newly created requests.
  • tlsuv_http_req_timeout(tlsuv_http_req_t *req, long millis): Sets or overrides the timeout for a specific request.
  • Added timeout field to struct tlsuv_http_req_s and request_timeout field to struct tlsuv_http_s.

  #### 2. Implementation Details (http.c)

  • Active-Only Scope: Timeouts only apply to in-flight requests once headers start sending; queued requests do not accrue time while waiting.
  • Shared Timer Management: Utilizes the shared c->conn_timer without conflicting with connect or idle keepalive timeouts, guarding starts and stops with timer_cb checks.
  • Lifecycle Integration: The request timer is started upon sending request headers and reliably stopped on request completion (including UV_EOF), cancellation, or errors.
  • Dynamic Re-arming: Updating the timeout on an active in-flight request dynamically resets and re-arms the timer.

  #### 3. Test Coverage (http_tests.cpp)

  • Client-level timeout: Confirms timeout fails with UV_ETIMEDOUT.
  • Per-request override: Verifies individual request timeouts without affecting adjacent requests.
  • Queued request isolation: Verifies queued requests are not charged for queue wait time.
  • Slow body transfer: Verifies timeout triggers during a slow/drip response body.
  • Idle keepalive co-existence: Ensures idle timeouts operate undisturbed after request completion.